### PR TITLE
[Feat/#36] 여행 태그 선택 기능 구현

### DIFF
--- a/JYP-iOS/JYP-iOS/Sources/Model/Tag.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Model/Tag.swift
@@ -12,4 +12,5 @@ struct Tag: Hashable {
     let id: String
     let text: String
     let type: JYPTagType
+    var isSelected: Bool = false
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagReactor.swift
@@ -32,15 +32,7 @@ final class CreatePlannerTagReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case let .selectTag(indexPath):
-            /// current Tag -> isSelecte toggle -> new Tag -> items 배열 replace
-            var items = currentState.sections[indexPath.section].items
-            let currentTag = items[indexPath.row]
-
-            guard case let TagItem.tagCell(reactor) = currentTag else { return .empty() }
-            var newTag = reactor.currentState
-            newTag.isSelected.toggle()
-
-            items.replaceSubrange(indexPath.row ... indexPath.row, with: [.tagCell(JYPTagCollectionViewCellReactor(tag: newTag))])
+            let items = remakeSelectedTagItems(indexPath: indexPath)
             return .just(.updateSectionItem(indexPath, items))
         }
     }
@@ -71,5 +63,24 @@ extension CreatePlannerTagReactor {
         let dislikeSection = TagSectionModel(model: .dislike(dislikeItems), items: dislikeItems.map { .tagCell(.init(tag: $0)) })
 
         return [sosoSection, likeSection, dislikeSection]
+    }
+}
+
+extension CreatePlannerTagReactor {
+    /// 선택된 tag의 isSelected를 변경하고, items 배열의 원래 요소와 교체함
+    /// - Parameter indexPath: 선택된 tag의 indexPath
+    /// - Returns: 선택된 태그의 상태가 반영된 전체 Item 배열
+    private func remakeSelectedTagItems(indexPath: IndexPath) -> [TagItem] {
+        /// current Tag -> isSelecte toggle -> new Tag -> items 배열 replace
+        var items = currentState.sections[indexPath.section].items
+        let currentTag = items[indexPath.row]
+
+        guard case let TagItem.tagCell(reactor) = currentTag else { return .init() }
+        var newTag = reactor.currentState
+        newTag.isSelected.toggle()
+
+        items.replaceSubrange(indexPath.row ... indexPath.row, with: [.tagCell(JYPTagCollectionViewCellReactor(tag: newTag))])
+        
+        return items
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagReactor.swift
@@ -33,10 +33,9 @@ final class CreatePlannerTagReactor: Reactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case let .selectTag(indexPath):
-            var tag = currentState.sections[indexPath.section].model.items[indexPath.row]
-            tag.isSelected = true
+            let tag = currentState.sections[indexPath.section].model.items[indexPath.row]
 
-            return .just(.toggleTagSelection(indexPath, TagItem.tagCell(tag)))
+            return .just(.toggleTagSelection(indexPath, .tagCell(.init(tag: tag))))
         }
     }
 
@@ -45,7 +44,6 @@ final class CreatePlannerTagReactor: Reactor {
 
         switch mutation {
         case let .toggleTagSelection(indexPath, tag):
-            let section = tag
             newState.sections[indexPath.section].items[indexPath.row] = tag
         }
 
@@ -57,9 +55,14 @@ extension CreatePlannerTagReactor {
     static func makeSections() -> [TagSectionModel] {
         let tags: [Tag] = [.init(id: "1", text: "모두 찬성", type: .soso), .init(id: "2", text: "상관없어", type: .soso), .init(id: "3", text: "고기", type: .like), .init(id: "4", text: "해산물", type: .like), .init(id: "5", text: "쇼핑", type: .like), .init(id: "6", text: "산", type: .like), .init(id: "7", text: "바다", type: .like), .init(id: "8", text: "도시", type: .like), .init(id: "9", text: "핫 플레이스", type: .like), .init(id: "10", text: "민초 치킨", type: .dislike), .init(id: "11", text: "단팥크림빵", type: .dislike), .init(id: "12", text: "약", type: .dislike)]
 
-        let sosoSection = TagSectionModel(model: .soso(tags.filter { $0.type == .soso }), items: tags.filter { $0.type == .soso }.map(TagSectionModel.Item.tagCell))
-        let likeSection = TagSectionModel(model: .like(tags.filter { $0.type == .like }), items: tags.filter { $0.type == .like }.map(TagSectionModel.Item.tagCell))
-        let dislikeSection = TagSectionModel(model: .dislike(tags.filter { $0.type == .dislike }), items: tags.filter { $0.type == .dislike }.map(TagSectionModel.Item.tagCell))
+        let sosoItems = tags.filter { $0.type == .soso }
+        let sosoSection = TagSectionModel(model: .soso(sosoItems), items: sosoItems.map { .tagCell(.init(tag: $0)) })
+
+        let likeItems = tags.filter { $0.type == .like }
+        let likeSection = TagSectionModel(model: .like(likeItems), items: tags.filter { $0.type == .like }.map { .tagCell(.init(tag: $0)) })
+
+        let dislikeItems = tags.filter { $0.type == .dislike }
+        let dislikeSection = TagSectionModel(model: .dislike(dislikeItems), items: dislikeItems.map { .tagCell(.init(tag: $0)) })
 
         return [sosoSection, likeSection, dislikeSection]
     }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagReactor.swift
@@ -11,18 +11,45 @@ import ReactorKit
 import RxDataSources
 
 final class CreatePlannerTagReactor: Reactor {
-    enum Action {}
+    enum Action {
+        case selectTag(IndexPath)
+    }
 
-    enum Mutation {}
+    enum Mutation {
+        case toggleTagSelection(IndexPath, TagSectionModel.Item)
+    }
 
     struct State {
         var sections: [TagSectionModel]
+        var isSelected: Bool = false
     }
 
     let initialState: State
 
     init() {
         initialState = State(sections: CreatePlannerTagReactor.makeSections())
+    }
+
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case let .selectTag(indexPath):
+            var tag = currentState.sections[indexPath.section].model.items[indexPath.row]
+            tag.isSelected = true
+
+            return .just(.toggleTagSelection(indexPath, TagItem.tagCell(tag)))
+        }
+    }
+
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState: State = state
+
+        switch mutation {
+        case let .toggleTagSelection(indexPath, tag):
+            let section = tag
+            newState.sections[indexPath.section].items[indexPath.row] = tag
+        }
+
+        return newState
     }
 }
 

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagViewController.swift
@@ -129,7 +129,6 @@ class CreatePlannerTagViewController: NavigationBarViewController, View {
     func bind(reactor: Reactor) {
         collectionView.rx.itemSelected
             .map { indexPath in Reactor.Action.selectTag(indexPath) }
-            .debug()
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagViewController.swift
@@ -29,10 +29,9 @@ class CreatePlannerTagViewController: NavigationBarViewController, View {
         switch item {
         case let .tagCell(tag):
             guard let cell = collectionView.dequeueReusableCell(
-                withReuseIdentifier: String(describing: JourneyTagCollectionViewCell.self),
+                withReuseIdentifier: String(describing: JYPTagCollectionViewCell.self),
                 for: indexPath
-            ) as? JourneyTagCollectionViewCell else { return .init() }
-            cell.update(title: tag.text)
+            ) as? JYPTagCollectionViewCell else { return .init() }
 
             return cell
         }
@@ -88,7 +87,7 @@ class CreatePlannerTagViewController: NavigationBarViewController, View {
         layout.scrollDirection = .vertical
 
         collectionView.register(PlannerTagCollectionReusableView.self, forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader, withReuseIdentifier: String(describing: PlannerTagCollectionReusableView.self))
-        collectionView.register(JourneyTagCollectionViewCell.self, forCellWithReuseIdentifier: String(describing: JourneyTagCollectionViewCell.self))
+        collectionView.register(JYPTagCollectionViewCell.self, forCellWithReuseIdentifier: String(describing: JYPTagCollectionViewCell.self))
         collectionView.rx.setDelegate(self).disposed(by: disposeBag)
     }
 
@@ -127,7 +126,12 @@ class CreatePlannerTagViewController: NavigationBarViewController, View {
     // MARK: - Bind Method
 
     func bind(reactor: Reactor) {
-        reactor.state.map(\.sections).asObservable()
+        collectionView.rx.itemSelected
+            .map { indexPath in Reactor.Action.selectTag(indexPath) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+
+        reactor.state.map(\.sections)
             .bind(to: collectionView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
     }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagViewController.swift
@@ -27,11 +27,12 @@ class CreatePlannerTagViewController: NavigationBarViewController, View {
 
     private lazy var dataSource = CreateTagDataSource { _, collectionView, indexPath, item -> UICollectionViewCell in
         switch item {
-        case let .tagCell(tag):
+        case let .tagCell(reactor):
             guard let cell = collectionView.dequeueReusableCell(
                 withReuseIdentifier: String(describing: JYPTagCollectionViewCell.self),
                 for: indexPath
             ) as? JYPTagCollectionViewCell else { return .init() }
+            cell.reactor = reactor
 
             return cell
         }
@@ -128,6 +129,7 @@ class CreatePlannerTagViewController: NavigationBarViewController, View {
     func bind(reactor: Reactor) {
         collectionView.rx.itemSelected
             .map { indexPath in Reactor.Action.selectTag(indexPath) }
+            .debug()
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
@@ -141,9 +143,12 @@ class CreatePlannerTagViewController: NavigationBarViewController, View {
 
 extension CreatePlannerTagViewController: UICollectionViewDelegateFlowLayout {
     func collectionView(_: UICollectionView, layout _: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-        let tags = dataSource[indexPath.section].model.items[indexPath.row]
+        let section = dataSource[indexPath.section].items[indexPath.row]
 
-        return CGSize(width: tags.text.size(withAttributes: [NSAttributedString.Key.font: JYPIOSFontFamily.Pretendard.medium.font(size: 16)]).width + 43, height: 32)
+        switch section {
+        case let .tagCell(reactor):
+            return CGSize(width: reactor.currentState.text.size(withAttributes: [NSAttributedString.Key.font: JYPIOSFontFamily.Pretendard.medium.font(size: 16)]).width + 50, height: 32)
+        }
     }
 
     func collectionView(_: UICollectionView, layout _: UICollectionViewLayout, referenceSizeForHeaderInSection _: Int) -> CGSize {

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagViewController.swift
@@ -132,8 +132,15 @@ class CreatePlannerTagViewController: NavigationBarViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
 
-        reactor.state.map(\.sections)
+        reactor.state
+            .map(\.sections)
             .bind(to: collectionView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
+
+        reactor.state
+            .map(\.isEnabledStartButton)
+            .distinctUntilChanged()
+            .bind(to: startButton.rx.isEnabled)
             .disposed(by: disposeBag)
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/TagSectionModel.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/TagSectionModel.swift
@@ -55,6 +55,6 @@ extension TagSection {
     }
 }
 
-enum TagItem: Equatable {
-    case tagCell(Tag)
+enum TagItem {
+    case tagCell(JYPTagCollectionViewCellReactor)
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/TagSectionModel.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/TagSectionModel.swift
@@ -17,17 +17,6 @@ enum TagSection: Equatable {
 }
 
 extension TagSection {
-    var items: [Tag] {
-        switch self {
-        case let .soso(tags):
-            return tags
-        case let .like(tags):
-            return tags
-        case let .dislike(tags):
-            return tags
-        }
-    }
-
     var title: String {
         switch self {
         case .soso: return "상관없어요 태그"

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Resuable/Cell/JYPTagCollectionViewCell.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Resuable/Cell/JYPTagCollectionViewCell.swift
@@ -28,7 +28,19 @@ class JYPTagCollectionViewCell: BaseCollectionViewCell, View {
     }
     
     func bind(reactor: Reactor) {
-        jypTag.type = reactor.currentState.type
-        jypTag.titleLabel.text = reactor.currentState.text
+        reactor.state
+            .map(\.type)
+            .bind(to: jypTag.rx.type)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map(\.text)
+            .bind(to: jypTag.titleLabel.rx.text)
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map(\.isSelected)
+            .bind(to: jypTag.rx.isSelected)
+            .disposed(by: disposeBag)
     }
 }


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
태그 선택 시 selected toggle 기능을 반영했습니다. 

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
태그의 현재 선택 여부를 저장하기 위해 `Tag` 모델 에 isSelected 항목이 추가되었습니다 (기본값이 지정되어있어 다른 코드 변경없음)

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->
sections의 items 항목이 get-only property여서 한 아이템만 업데이트가 불가능했습니다. 
불가피하게 tag의 상태를 업데이트 해준 후, 현재 items 배열에 있던 기존 tag와 replace 후 전체 배열을 업데이트하는 방식으로 구현했습니다.
`remakeSelectedTagItems` 메소드 참고 부탁드립니다 .. 

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #36 


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->