### PR TITLE
[Feat/#70] 여행 플랜 (Journey Plan) #5

### DIFF
--- a/JYP-iOS/JYP-iOS/Sources/Extension/DateManager.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Extension/DateManager.swift
@@ -24,4 +24,8 @@ struct DateManager {
 
         return Self.dataFormatter.date(from: date) ?? Date()
     }
+    
+    static func addDateComponent(byAdding: Calendar.Component, value: Int, to: Date) -> Date {
+        return Calendar.current.date(byAdding: byAdding, value: value, to: to) ?? to
+    }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Network/Service/JourneyService.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Network/Service/JourneyService.swift
@@ -60,8 +60,8 @@ final class JourneyService: BaseService, JourneyServiceType {
         return .just(
             Journey(id: "1",
                        name: "테스트1",
-                       startDate: 0.0,
-                       endDate: 0.0,
+                       startDate: 1662181200,
+                       endDate: 1662699600,
                     themePath: .city,
                        users: [User(id: "1",
                                     nickname: "닉네임1",

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/JourenyPlan/Cell/PikiCollectionReusableView.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/JourenyPlan/Cell/PikiCollectionReusableView.swift
@@ -9,7 +9,6 @@
 import UIKit
 
 class PikiCollectionReusableView: BaseCollectionReusableView {
-    
     // MARK: - UI Components
     
     let titleLabel: UILabel = .init()

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/JourenyPlan/Cell/PikiCollectionReusableView.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/JourenyPlan/Cell/PikiCollectionReusableView.swift
@@ -7,8 +7,11 @@
 //
 
 import UIKit
+import ReactorKit
 
-class PikiCollectionReusableView: BaseCollectionReusableView {
+class PikiCollectionReusableView: BaseCollectionReusableView, View {
+    typealias Reactor = PikiCollectionReusableViewReactor
+    
     // MARK: - UI Components
     
     let titleLabel: UILabel = .init()
@@ -22,11 +25,9 @@ class PikiCollectionReusableView: BaseCollectionReusableView {
         
         titleLabel.font = JYPIOSFontFamily.Pretendard.semiBold.font(size: 16)
         titleLabel.textColor = JYPIOSAsset.textB80.color
-        titleLabel.text = "Day 1"
         
         subLabel.font = JYPIOSFontFamily.Pretendard.medium.font(size: 16)
         subLabel.textColor = JYPIOSAsset.textB40.color
-        subLabel.text = "7월 18일"
         
         trailingButton.setImage(JYPIOSAsset.iconModify.image, for: .normal)
     }
@@ -55,5 +56,11 @@ class PikiCollectionReusableView: BaseCollectionReusableView {
             $0.centerY.equalToSuperview()
             $0.width.height.equalTo(24)
         }
+    }
+    
+    func bind(reactor: Reactor) {
+        titleLabel.text = "Day \(reactor.currentState.order + 1)"
+        
+        subLabel.text = DateManager.dateToString(format: "M월 d일", date: reactor.currentState.date)
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/JourenyPlan/Cell/PikiCollectionReusableViewReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/JourenyPlan/Cell/PikiCollectionReusableViewReactor.swift
@@ -1,18 +1,21 @@
 //
-//  RouteCollectionViewCellReactor.swift
+//  PikiCollectionReusableViewReactor.swift
 //  JYP-iOS
 //
-//  Created by 송영모 on 2022/08/30.
+//  Created by 송영모 on 2022/09/03.
 //  Copyright © 2022 JYP-iOS. All rights reserved.
 //
 
+import Foundation
 import ReactorKit
 
-class RouteCollectionViewCellReactor: Reactor {
+class PikiCollectionReusableViewReactor: Reactor {
     enum Action { }
     enum Mutation { }
+    
     struct State {
-        let pik: Pik
+        let order: Int
+        let date: Date
     }
     
     var initialState: State

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/JourenyPlan/Cell/PikiCollectionViewCell.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/JourenyPlan/Cell/PikiCollectionViewCell.swift
@@ -12,9 +12,15 @@ import ReactorKit
 class PikiCollectionViewCellReactor: Reactor {
     typealias Action = NoAction
     
-    var initialState: Pik
+    struct State {
+        var order: Int
+        var date: Date
+        var pik: Pik
+    }
     
-    init(state: Pik) {
+    var initialState: State
+    
+    init(state: State) {
         initialState = state
     }
 }
@@ -114,9 +120,9 @@ class PikiCollectionViewCell: BaseCollectionViewCell, View {
     }
     
     func bind(reactor: Reactor) {
-        titleLabel.text = reactor.currentState.name
-        subLabel.text = reactor.currentState.address
-        categoryImageView.image = reactor.currentState.category.image
-        categoryLabel.text = reactor.currentState.category.title
+        titleLabel.text = reactor.currentState.pik.name
+        subLabel.text = reactor.currentState.pik.address
+        categoryImageView.image = reactor.currentState.pik.category.image
+        categoryLabel.text = reactor.currentState.pik.category.title
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/JourenyPlan/JourneyPlanReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/JourenyPlan/JourneyPlanReactor.swift
@@ -11,6 +11,7 @@ import ReactorKit
 
 class JourneyPlanReactor: Reactor {
     enum Action {
+        case tapPikiHeaderEditButton(IndexPath)
         case tapEmptyPikiPlusButton(IndexPath)
     }
     
@@ -33,12 +34,16 @@ class JourneyPlanReactor: Reactor {
 
 extension JourneyPlanReactor {
     func mutate(action: Action) -> Observable<Mutation> {
-        let state = self.currentState
-        
         switch action {
+        case let .tapPikiHeaderEditButton(indexPath):
+            if let reactor = makeReactor(from: indexPath) {
+                provider.plannerService.event.onNext(.presentPlannerRoute(reactor))
+            }
+            return .empty()
         case let .tapEmptyPikiPlusButton(indexPath):
-            guard case let .emptyPiki(reactor) = state.sections[indexPath.section].items[indexPath.row] else { return .empty() }
-            provider.plannerService.event.onNext(.presentPlannerRoute(makeReactor(from: reactor)))
+            if let reactor = makeReactor(from: indexPath) {
+                provider.plannerService.event.onNext(.presentPlannerRoute(reactor))
+            }
             return .empty()
         }
     }
@@ -68,8 +73,16 @@ extension JourneyPlanReactor {
         
         return newState
     }
-    
-    private func makeReactor(from reactor: EmptyPikiCollectionViewCellReactor) -> PlannerRouteReactor {
-        return .init(state: .init(order: reactor.currentState.order, date: reactor.currentState.date, pikmis: provider.plannerService.journey?.pikmis ?? []))
+
+    private func makeReactor(from indexPath: IndexPath) -> PlannerRouteReactor? {
+        guard let journey = provider.plannerService.journey else { return nil }
+        
+        let order: Int = indexPath.section - 1
+        let date: Date = Date(timeIntervalSince1970: journey.startDate)
+        let addedDate: Date = DateManager.addDateComponent(byAdding: .day, value: order, to: date)
+        let pikis: [Pik] = journey.pikis?[indexPath.section] ?? []
+        let pikmis: [Pik] = journey.pikmis ?? []
+        
+        return .init(state: .init(order: order, date: addedDate, pikis: pikis, pikmis: pikmis))
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/JourenyPlan/JourneyPlanReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/JourenyPlan/JourneyPlanReactor.swift
@@ -23,7 +23,7 @@ class JourneyPlanReactor: Reactor {
         var sections: [JourneyPlanSectionModel]
     }
     
-    let provider = ServiceProvider.shared.plannerService
+    let provider = ServiceProvider.shared
     var initialState: State
     
     init() {
@@ -38,16 +38,16 @@ extension JourneyPlanReactor {
         switch action {
         case let .tapEmptyPikiPlusButton(indexPath):
             guard case let .emptyPiki(reactor) = state.sections[indexPath.section].items[indexPath.row] else { return .empty() }
-            provider.event.onNext(.presentPlannerRoute(makeReactor(from: reactor)))
+            provider.plannerService.event.onNext(.presentPlannerRoute(makeReactor(from: reactor)))
             return .empty()
         }
     }
     
     func transform(mutation: Observable<Mutation>) -> Observable<Mutation> {
-        let eventMutation = provider.event.withUnretained(self).flatMap { (this, event) -> Observable<Mutation> in
+        let eventMutation = provider.plannerService.event.withUnretained(self).flatMap { (this, event) -> Observable<Mutation> in
             switch event {
             case let .fetchJourney(journey):
-                return Observable.just(Mutation.setSections(this.provider.makeSections(from: journey)))
+                return Observable.just(Mutation.setSections(this.provider.plannerService.makeSections(from: journey)))
             default:
                 return .empty()
             }
@@ -70,6 +70,6 @@ extension JourneyPlanReactor {
     }
     
     private func makeReactor(from reactor: EmptyPikiCollectionViewCellReactor) -> PlannerRouteReactor {
-        return .init(state: .init(order: reactor.currentState.order, date: reactor.currentState.date, pikmis: provider.journey?.pikmis ?? []))
+        return .init(state: .init(order: reactor.currentState.order, date: reactor.currentState.date, pikmis: provider.plannerService.journey?.pikmis ?? []))
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/PlannerService.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/PlannerService.swift
@@ -63,12 +63,12 @@ class PlannerService: PlannerServiceProtocol {
             var journeyPlanItems: [JourneyPlanItem] = []
             
             if pikis.isEmpty {
-                let sectionItem = JourneyPlanItem.emptyPiki(EmptyPikiCollectionViewCellReactor(state: .init(order: index, date: Date())))
+                let sectionItem = JourneyPlanItem.emptyPiki(EmptyPikiCollectionViewCellReactor(state: .init(order: index, date: DateManager.addDateComponent(byAdding: .day, value: index, to: Date(timeIntervalSince1970: journey.startDate)))))
                 
                 journeyPlanItems.append(sectionItem)
             } else {
-                let sectionItems = pikis.map { (piki) -> JourneyPlanItem in
-                    return JourneyPlanItem.piki(PikiCollectionViewCellReactor(state: piki))
+                let sectionItems = pikis.map { (pik) -> JourneyPlanItem in
+                    return JourneyPlanItem.piki(PikiCollectionViewCellReactor(state: .init(order: index, date: DateManager.addDateComponent(byAdding: .day, value: index, to: Date(timeIntervalSince1970: journey.startDate)), pik: pik)))
                 }
                 
                 journeyPlanItems.append(contentsOf: sectionItems)

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/Components/Cell/PikmiRouteCollectionReusableView.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/Components/Cell/PikmiRouteCollectionReusableView.swift
@@ -8,8 +8,7 @@
 
 import UIKit
 
-class PikmiRouteCollectionReusableView: BaseCollectionReusableView {
-    
+class PikmiRouteCollectionReusableView: BaseCollectionReusableView { 
     // MARK: - UI Components
     
     let titleLabel: UILabel = .init()

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/Components/Cell/PikmiRouteCollectionViewCell.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/Components/Cell/PikmiRouteCollectionViewCell.swift
@@ -19,6 +19,12 @@ class PikmiRouteCollectionViewCell: BaseCollectionViewCell, View {
     let rankBadgeImageView: UIImageView = .init()
     let categoryLabel: UILabel = .init()
     
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        rankBadgeImageView.image = nil
+    }
+    
     // MARK: - Setup Methods
     
     override func setupProperty() {
@@ -60,7 +66,7 @@ class PikmiRouteCollectionViewCell: BaseCollectionViewCell, View {
         rankBadgeImageView.snp.makeConstraints {
             $0.top.equalToSuperview()
             $0.trailing.equalToSuperview().inset(23)
-            $0.width.equalTo(26)
+//            $0.width.equalTo(26)
         }
     }
     

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/Components/Cell/RouteCollectionViewCell.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/Components/Cell/RouteCollectionViewCell.swift
@@ -74,7 +74,7 @@ class RouteCollectionViewCell: BaseCollectionViewCell, View {
     // MARK: - Bind Method
     
     func bind(reactor: Reactor) {
-        subLabel.text = reactor.currentState.pik?.category.title
-        titleLabel.text = reactor.currentState.pik?.name
+        subLabel.text = reactor.currentState.pik.category.title
+        titleLabel.text = reactor.currentState.pik.name
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/PlannerRouteReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/PlannerRouteReactor.swift
@@ -12,11 +12,13 @@ import ReactorKit
 class PlannerRouteReactor: Reactor {
     enum Action {
         case refresh
+        case tapRouteCell(IndexPath)
         case tapPikmiRouteCell(IndexPath)
     }
     enum Mutation {
-        case setPikmiRouteSections([PikmiRouteSectionModel])
         case setRouteSections([RouteSectionModel])
+        case deleteRouteSectionItem(IndexPath)
+        case setPikmiRouteSections([PikmiRouteSectionModel])
         case updatePikmiRouteSectionItem(IndexPath, PikmiRouteSectionModel.Item)
         case updateRouteSectionItem(IndexPath, RouteSectionModel.Item)
         case appendRouteSectionItem(IndexPath, RouteSectionModel.Item)
@@ -47,6 +49,8 @@ extension PlannerRouteReactor {
                 .just(.setRouteSections(makeSections())),
                 .just(.setPikmiRouteSections(makeSections(pikmis: currentState.pikmis)))
             ])
+        case let .tapRouteCell(indexPath):
+            return .just(.deleteRouteSectionItem(indexPath))
         case let .tapPikmiRouteCell(indexPath):
             guard case let .pikmiRoute(reactor) = currentState.pikmiRouteSections[indexPath.section].items[indexPath.row] else { return .empty() }
             let item = RouteSectionModel.Item.route(.init(state: .init(pik: reactor.currentState.pik)))
@@ -59,10 +63,12 @@ extension PlannerRouteReactor {
         var newState = state
         
         switch mutation {
-        case let .setPikmiRouteSections(sections):
-            newState.pikmiRouteSections = sections
         case let .setRouteSections(sections):
             newState.routeSections = sections
+        case let .deleteRouteSectionItem(indexPath):
+            newState.routeSections[indexPath.section].items.remove(at: indexPath.row)
+        case let .setPikmiRouteSections(sections):
+            newState.pikmiRouteSections = sections
         case let .updatePikmiRouteSectionItem(indexPath, item):
             newState.pikmiRouteSections[indexPath.section].items[indexPath.row] = item
         case let .updateRouteSectionItem(indexPath, item):

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/PlannerRouteReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/PlannerRouteReactor.swift
@@ -27,6 +27,7 @@ class PlannerRouteReactor: Reactor {
     struct State {
         let order: Int
         let date: Date
+        let pikis: [Pik]
         let pikmis: [Pik]
         
         var routeSections: [RouteSectionModel] = []
@@ -46,7 +47,7 @@ extension PlannerRouteReactor {
         switch action {
         case .refresh:
             return .concat([
-                .just(.setRouteSections(makeSections())),
+                .just(.setRouteSections(makeSections(pikis: currentState.pikis))),
                 .just(.setPikmiRouteSections(makeSections(pikmis: currentState.pikmis)))
             ])
         case let .tapRouteCell(indexPath):
@@ -80,8 +81,16 @@ extension PlannerRouteReactor {
         return newState
     }
     
-    private func makeSections() -> [RouteSectionModel] {
-        return [RouteSectionModel.init(model: .route([RouteItem.route(.init(state: .init(pik: nil)))]), items: [])]
+    private func makeSections(pikis: [Pik]) -> [RouteSectionModel] {
+        if pikis.isEmpty {
+            return [RouteSectionModel.init(model: .route([RouteItem.route(.init(state: .init(pik: Pik(id: "", name: "", address: "", category: .etc, likeBy: nil, longitude: 0.0, latitude: 0.0, link: ""))))]), items: [])]
+        }
+        
+        let routeItems = pikis.map({ (pik) -> RouteItem in
+            return .route(.init(state: .init(pik: pik)))
+        })
+        
+        return [RouteSectionModel.init(model: .route(routeItems), items: routeItems)]
     }
     
     private func makeSections(pikmis: [Pik]) -> [PikmiRouteSectionModel] {

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/PlannerRouteViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/PlannerRouteViewController.swift
@@ -118,6 +118,11 @@ class PlannerRouteViewController: NavigationBarViewController, View {
             .bind(to: reactor.action)
             .disposed(by: disposeBag)
         
+        routeCollectionView.rx.itemSelected
+            .map { .tapRouteCell($0) }
+            .bind(to: reactor.action)
+            .disposed(by: disposeBag)
+        
         pikmiRouteCollectionView.rx.itemSelected
             .map { .tapPikmiRouteCell($0) }
             .bind(to: reactor.action)

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/PlannerRouteViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/PlannerRouteViewController.swift
@@ -152,11 +152,7 @@ class PlannerRouteViewController: NavigationBarViewController, View {
                 this.routeCollectionView.collectionViewLayout = layout
                 
                 if let section = sections.first {
-                    if section.items.isEmpty {
-                        this.emptyLabel.isHidden = false
-                    } else {
-                        this.emptyLabel.isHidden = true
-                    }
+                    this.emptyLabel.isHidden = !section.items.isEmpty
                 }
             }
             .disposed(by: disposeBag)

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/PlannerRouteViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/PlannerRouteViewController.swift
@@ -129,6 +129,22 @@ class PlannerRouteViewController: NavigationBarViewController, View {
             .disposed(by: disposeBag)
         
         reactor.state
+            .map(\.order)
+            .withUnretained(self)
+            .bind { this, order in
+                this.setNavigationBarTitleText("DAY \(order + 1)")
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map(\.date)
+            .withUnretained(self)
+            .bind { this, date in
+                this.setNavigationBarSubTitleText(DateManager.dateToString(format: "M월 d일", date: date))
+            }
+            .disposed(by: disposeBag)
+        
+        reactor.state
             .map(\.routeSections)
             .withUnretained(self)
             .bind { this, sections in

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/PlannerRouteViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/PlannerRoute/PlannerRouteViewController.swift
@@ -15,7 +15,7 @@ class PlannerRouteViewController: NavigationBarViewController, View {
     
     // MARK: - UI Components
     
-    let emptyView: UIView = .init()
+    let emptyLabel: UILabel = .init()
     let routeCollectionView: UICollectionView = .init(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     let pikmiRouteCollectionView: UICollectionView = .init(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
     
@@ -73,6 +73,10 @@ class PlannerRouteViewController: NavigationBarViewController, View {
     override func setupProperty() {
         super.setupProperty()
         
+        emptyLabel.text = "방문할 장소를 선택해 주세요"
+        emptyLabel.textColor = JYPIOSAsset.textB40.color
+        emptyLabel.font = JYPIOSFontFamily.Pretendard.regular.font(size: 16)
+        
         routeCollectionView.backgroundColor = JYPIOSAsset.backgroundWhite200.color
         routeCollectionView.register(RouteCollectionViewCell.self, forCellWithReuseIdentifier: String(describing: RouteCollectionViewCell.self))
         
@@ -86,6 +90,8 @@ class PlannerRouteViewController: NavigationBarViewController, View {
         super.setupHierarchy()
         
         contentView.addSubviews([routeCollectionView, pikmiRouteCollectionView])
+        
+        routeCollectionView.addSubviews([emptyLabel])
     }
     
     override func setupLayout() {
@@ -94,6 +100,10 @@ class PlannerRouteViewController: NavigationBarViewController, View {
         routeCollectionView.snp.makeConstraints {
             $0.top.leading.trailing.equalToSuperview()
             $0.height.equalTo(140)
+        }
+        
+        emptyLabel.snp.makeConstraints {
+            $0.center.equalToSuperview()
         }
         
         pikmiRouteCollectionView.snp.makeConstraints {
@@ -119,6 +129,14 @@ class PlannerRouteViewController: NavigationBarViewController, View {
             .bind { this, sections in
                 let layout = this.makeRouteLayout(sections: sections)
                 this.routeCollectionView.collectionViewLayout = layout
+                
+                if let section = sections.first {
+                    if section.items.isEmpty {
+                        this.emptyLabel.isHidden = false
+                    } else {
+                        this.emptyLabel.isHidden = true
+                    }
+                }
             }
             .disposed(by: disposeBag)
         


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
아마도 여행 플랜 탭은 이제 거의 끝나서, 다시 토론장 개발을 시작하려고 합니닷

-> 뒤로 갔다오면 day 컬렉션뷰가 초기화되는 문제가 있는데, 토론장 고치면서 시도해보겠습니당.

같은 state 변수의 바인딩 처리를 묶고 싶은데, 혹시 어떻게 해야할지 아신다면 , , 피드백 주시면 바로 반영하겠습니다 !

```swift
reactor.state
    .map(\.pikmiRouteSections)
    .bind(to: pikmiRouteCollectionView.rx.items(dataSource: pikmiRouteDataSource))
    .disposed(by: disposeBag)

reactor.state
    .map(\.pikmiRouteSections)
    .withUnretained(self)
    .bind { this, sections in
        let layout = this.makePikmiRouteLayout(sections: sections)
        this.pikmiRouteCollectionView.collectionViewLayout = layout
    }
    .disposed(by: disposeBag)
```


#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->

https://user-images.githubusercontent.com/77970826/188258326-df4b526e-0afb-42eb-88d5-55528eac59c8.mp4

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #70


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->