### PR TITLE
[Feat/#97] 참여코드로 플래너 입장 구현

### DIFF
--- a/JYP-iOS/JYP-iOS/Resources/Assets.xcassets/icon_x delete.imageset/Contents.json
+++ b/JYP-iOS/JYP-iOS/Resources/Assets.xcassets/icon_x delete.imageset/Contents.json
@@ -1,0 +1,21 @@
+{
+  "images" : [
+    {
+      "filename" : "icon_x delete.svg",
+      "idiom" : "universal",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "universal",
+      "scale" : "3x"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/JYP-iOS/JYP-iOS/Resources/Assets.xcassets/icon_x delete.imageset/icon_x delete.svg
+++ b/JYP-iOS/JYP-iOS/Resources/Assets.xcassets/icon_x delete.imageset/icon_x delete.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.34314 6.65674L17.6568 17.9704" stroke="#2C2C2C" stroke-width="2.6" stroke-linecap="round"/>
+<path d="M17.6569 6.65674L6.34315 17.9704" stroke="#2C2C2C" stroke-width="2.6" stroke-linecap="round"/>
+</svg>

--- a/JYP-iOS/JYP-iOS/Sources/Base/NavigationBarViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Base/NavigationBarViewController.swift
@@ -12,6 +12,7 @@ class NavigationBar: UIView {
     var backButton = UIButton()
     var title = UILabel()
     var subTitle = UILabel()
+    var closeButton = UIButton()
 }
 
 protocol BaseNavigationBarViewControllerProtocol: AnyObject {
@@ -24,6 +25,7 @@ protocol BaseNavigationBarViewControllerProtocol: AnyObject {
     func setNavigationBarHidden(_ hidden: Bool)
     func setNavigationBarBackButtonHidden(_ hidden: Bool)
     func setNavigationBarBackButtonTintColor(_ color: UIColor)
+    func setNavigationBarCloseButtonHidden(_ hidden: Bool)
     func setNavigationBarTitleText(_ text: String?)
     func setNavigationBarTitleFont(_ font: UIFont?)
     func setNavigationBarTitleTextColor(_ color: UIColor?)
@@ -65,8 +67,10 @@ class NavigationBarViewController: BaseViewController, BaseNavigationBarViewCont
         setNavigationBarTitleTextColor(titleTextColor)
         setNavigationBarSubTitleFont(subTitleFont)
         setNavigationBarSubTitleTextColor(subTitleTextColor)
+        setNavigationBarCloseButtonHidden(true)
         navigationBar.backButton.setImage(JYPIOSAsset.iconBack.image, for: .normal)
         navigationBar.backButton.tintColor = JYPIOSAsset.subBlack.color
+        navigationBar.closeButton.setImage(JYPIOSAsset.iconXDelete.image, for: .normal)
     }
     
     override func setupHierarchy() {
@@ -74,7 +78,7 @@ class NavigationBarViewController: BaseViewController, BaseNavigationBarViewCont
         
         view.addSubviews([statusBar, navigationBar, contentView])
       
-        navigationBar.addSubviews([navigationBar.title, navigationBar.backButton, navigationBar.subTitle])
+        navigationBar.addSubviews([navigationBar.title, navigationBar.backButton, navigationBar.subTitle, navigationBar.closeButton])
     }
     
     override func setupLayout() {
@@ -107,6 +111,12 @@ class NavigationBarViewController: BaseViewController, BaseNavigationBarViewCont
             $0.centerY.equalToSuperview()
         }
         
+        navigationBar.closeButton.snp.makeConstraints {
+            $0.trailing.equalToSuperview().inset(20)
+            $0.centerY.equalToSuperview()
+            $0.width.height.equalTo(24)
+        }
+        
         contentView.snp.makeConstraints {
             $0.top.equalTo(statusBar.snp.bottom).offset(60)
             $0.leading.trailing.equalTo(view.safeAreaLayoutGuide)
@@ -118,6 +128,12 @@ class NavigationBarViewController: BaseViewController, BaseNavigationBarViewCont
         navigationBar.backButton.rx.tap
             .bind { [weak self] _ in
                 self?.navigationController?.popViewController(animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        navigationBar.closeButton.rx.tap
+            .bind { [weak self] _ in
+                self?.dismiss(animated: true)
             }
             .disposed(by: disposeBag)
     }
@@ -149,6 +165,10 @@ class NavigationBarViewController: BaseViewController, BaseNavigationBarViewCont
     
     func setNavigationBarBackButtonTintColor(_ color: UIColor) {
         navigationBar.backButton.setImage(JYPIOSAsset.iconBack.image.withTintColor(color), for: .normal)
+    }
+    
+    func setNavigationBarCloseButtonHidden(_ hidden: Bool) {
+        navigationBar.closeButton.isHidden = hidden
     }
     
     func setNavigationBarTitleText(_ text: String?) {

--- a/JYP-iOS/JYP-iOS/Sources/CompositionRoot.swift
+++ b/JYP-iOS/JYP-iOS/Sources/CompositionRoot.swift
@@ -74,7 +74,7 @@ extension CompositionRoot {
         let pushInputPlannerCodeBottomSheetScreen: () -> InputPlannerCodeBottomSheetViewController = {
             let reactor = InputPlannerCodeBottomSheetReactor()
             let controller = InputPlannerCodeBottomSheetViewController(reactor: reactor,
-                                                                       pushPlannerInviteScreen: pushPlannerInviteScreen)
+                                                                       pushPlannerScreen: pushPlannerScreen)
             
             return controller
         }

--- a/JYP-iOS/JYP-iOS/Sources/CompositionRoot.swift
+++ b/JYP-iOS/JYP-iOS/Sources/CompositionRoot.swift
@@ -19,7 +19,7 @@ final class CompositionRoot {
         window.backgroundColor = .white
         window.makeKeyAndVisible()
         
-        window.rootViewController = makeTabBarScreen()
+        window.rootViewController = UINavigationController(rootViewController: makeTabBarScreen())
         
         return AppDependency(window: window,
                              configureAppearance: self.configureAppearance)
@@ -71,13 +71,16 @@ extension CompositionRoot {
             return controller
         }
         
-        let pushJoinPlannerTagScreen: () -> CreatePlannerTagViewController = {
+        let pushJoinPlannerTagScreen: (_ id: String) -> CreatePlannerTagViewController = { id in
             let reactor = CreatePlannerTagReactor(
                 provider: ServiceProvider.shared,
-                journey: .init(id: "", name: "", startDate: 0.0, endDate: 0.0, themePath: .default, users: []),
+                journey: .init(id: id, name: "", startDate: 0.0, endDate: 0.0, themePath: .default, users: []),
                 viewMode: .join
             )
-            let viewController = CreatePlannerTagViewController(reactor: reactor)
+            let viewController = CreatePlannerTagViewController(
+                reactor: reactor,
+                pushPlannerScreen: pushPlannerScreen
+            )
             return viewController
         }
         
@@ -85,8 +88,7 @@ extension CompositionRoot {
             let reactor = InputPlannerCodeBottomSheetReactor()
             let controller = InputPlannerCodeBottomSheetViewController(
                 reactor: reactor,
-                pushPlannerScreen: pushPlannerScreen,
-                pushCreatePlannerTagScreen: pushJoinPlannerTagScreen
+                pushJoinPlannerTagScreen: pushJoinPlannerTagScreen
             )
             
             return controller

--- a/JYP-iOS/JYP-iOS/Sources/CompositionRoot.swift
+++ b/JYP-iOS/JYP-iOS/Sources/CompositionRoot.swift
@@ -71,10 +71,11 @@ extension CompositionRoot {
             return controller
         }
         
-        let pushCreatePlannerTagScreen: () -> CreatePlannerTagViewController = {
+        let pushJoinPlannerTagScreen: () -> CreatePlannerTagViewController = {
             let reactor = CreatePlannerTagReactor(
                 provider: ServiceProvider.shared,
-                journey: .init(id: "", name: "", startDate: 0.0, endDate: 0.0, themePath: .default, users: [])
+                journey: .init(id: "", name: "", startDate: 0.0, endDate: 0.0, themePath: .default, users: []),
+                viewMode: .join
             )
             let viewController = CreatePlannerTagViewController(reactor: reactor)
             return viewController
@@ -85,7 +86,7 @@ extension CompositionRoot {
             let controller = InputPlannerCodeBottomSheetViewController(
                 reactor: reactor,
                 pushPlannerScreen: pushPlannerScreen,
-                pushCreatePlannerTagScreen: pushCreatePlannerTagScreen
+                pushCreatePlannerTagScreen: pushJoinPlannerTagScreen
             )
             
             return controller

--- a/JYP-iOS/JYP-iOS/Sources/CompositionRoot.swift
+++ b/JYP-iOS/JYP-iOS/Sources/CompositionRoot.swift
@@ -71,10 +71,22 @@ extension CompositionRoot {
             return controller
         }
         
+        let pushCreatePlannerTagScreen: () -> CreatePlannerTagViewController = {
+            let reactor = CreatePlannerTagReactor(
+                provider: ServiceProvider.shared,
+                journey: .init(id: "", name: "", startDate: 0.0, endDate: 0.0, themePath: .default, users: [])
+            )
+            let viewController = CreatePlannerTagViewController(reactor: reactor)
+            return viewController
+        }
+        
         let pushInputPlannerCodeBottomSheetScreen: () -> InputPlannerCodeBottomSheetViewController = {
             let reactor = InputPlannerCodeBottomSheetReactor()
-            let controller = InputPlannerCodeBottomSheetViewController(reactor: reactor,
-                                                                       pushPlannerScreen: pushPlannerScreen)
+            let controller = InputPlannerCodeBottomSheetViewController(
+                reactor: reactor,
+                pushPlannerScreen: pushPlannerScreen,
+                pushCreatePlannerTagScreen: pushCreatePlannerTagScreen
+            )
             
             return controller
         }

--- a/JYP-iOS/JYP-iOS/Sources/Network/API/JourneyAPI.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Network/API/JourneyAPI.swift
@@ -19,7 +19,7 @@ enum JourneyAPI {
     case updateTags(journeyId: String, request: UpdateTagsRequest)
     case createPikmi(journeyId: String, request: CreatePikmiRequest)
     case updatePikis(journeyId: String, request: UpdatePikisRequest)
-    case createJourneyUser(journeyId: String, request: CreateJourneyUserRequest)
+    case joinPlanner(journeyId: String, request: CreateJourneyUserRequest)
     case deleteJourneyUser(journeyId: String)
     case createPikmiLike(journeyId: String, pikmiId: String)
     case deletePikmiLike(journeyId: String, pikmiId: String)
@@ -59,7 +59,7 @@ extension JourneyAPI: BaseAPI {
         case let .updatePikis(id, _):
             return "/\(id)/pikis"
             
-        case let .createJourneyUser(id, _):
+        case let .joinPlanner(id, _):
             return "/\(id)/join"
 
         case let .deleteJourneyUser(id):
@@ -78,7 +78,7 @@ extension JourneyAPI: BaseAPI {
         case .fetchJourneys, .fetchDefaultTags, .fetchJourneyTags, .fetchJourney, .fetchTags:
             return .get
             
-        case .createJourney, .createPikmi, .createJourneyUser, .createPikmiLike, .updateTags, .updatePikis, .deleteJourneyUser, .deletePikmiLike:
+        case .createJourney, .createPikmi, .joinPlanner, .createPikmiLike, .updateTags, .updatePikis, .deleteJourneyUser, .deletePikmiLike:
             return .post
         }
     }
@@ -106,7 +106,7 @@ extension JourneyAPI: BaseAPI {
         case let .updatePikis(_, request):
             return .requestJSONEncodable(request)
             
-        case let .createJourneyUser(_, request):
+        case let .joinPlanner(_, request):
             return .requestJSONEncodable(request)
         }
     }

--- a/JYP-iOS/JYP-iOS/Sources/Network/API/JourneyAPI.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Network/API/JourneyAPI.swift
@@ -114,7 +114,7 @@ extension JourneyAPI: BaseAPI {
     var headers: [String: String]? {
         [
             "jyp-jwt-master-key": Environment.jwtKey,
-            "jyp-override-id": "2"
+            "jyp-override-id": "1"
         ]
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Network/Service/JourneyService.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Network/Service/JourneyService.swift
@@ -31,7 +31,7 @@ protocol JourneyServiceType {
     func createPikmi(id: String, name: String, address: String, category: JYPCategoryType, longitude: Double, latitude: Double, link: String)
     func updatePikis(journeyId: String, request: UpdatePikisRequest)
     func editTags(journeyId: String, request: UpdateTagsRequest) -> Observable<EmptyModel>
-    func addJourneyUser(journeyId: String, request: CreateJourneyUserRequest) -> Observable<EmptyModel>
+    func joinPlanner(journeyId: String) -> Observable<EmptyModel>
     func deleteJourneyUser(journeyId: String) -> Observable<EmptyModel>
     func addPikmiLike(journeyId: String, pikmiId: String) -> Observable<EmptyModel>
     func deletePikmiLike(journeyId: String, pikmiId: String) -> Observable<EmptyModel>
@@ -154,8 +154,11 @@ final class JourneyService: BaseService, JourneyServiceType {
             .asObservable()
     }
 
-    func addJourneyUser(journeyId: String, request: CreateJourneyUserRequest) -> Observable<EmptyModel> {
-        let target = JourneyAPI.createJourneyUser(journeyId: journeyId, request: request)
+    func joinPlanner(journeyId: String) -> Observable<EmptyModel> {
+        let target = JourneyAPI.joinPlanner(
+            journeyId: journeyId,
+            request: .init(tags: [])
+        )
 
         return APIService.request(target: target)
             .map(EmptyModel.self)

--- a/JYP-iOS/JYP-iOS/Sources/Network/Service/JourneyService.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Network/Service/JourneyService.swift
@@ -31,7 +31,7 @@ protocol JourneyServiceType {
     func createPikmi(id: String, name: String, address: String, category: JYPCategoryType, longitude: Double, latitude: Double, link: String)
     func updatePikis(journeyId: String, request: UpdatePikisRequest)
     func editTags(journeyId: String, request: UpdateTagsRequest) -> Observable<EmptyModel>
-    func joinPlanner(journeyId: String) -> Observable<EmptyModel>
+    func joinPlanner(journeyId: String, request: CreateJourneyUserRequest) -> Observable<EmptyModel>
     func deleteJourneyUser(journeyId: String) -> Observable<EmptyModel>
     func addPikmiLike(journeyId: String, pikmiId: String) -> Observable<EmptyModel>
     func deletePikmiLike(journeyId: String, pikmiId: String) -> Observable<EmptyModel>
@@ -154,10 +154,10 @@ final class JourneyService: BaseService, JourneyServiceType {
             .asObservable()
     }
 
-    func joinPlanner(journeyId: String) -> Observable<EmptyModel> {
+    func joinPlanner(journeyId: String, request: CreateJourneyUserRequest) -> Observable<EmptyModel> {
         let target = JourneyAPI.joinPlanner(
             journeyId: journeyId,
-            request: .init(tags: [])
+            request: request
         )
 
         return APIService.request(target: target)

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerDate/CreatePlannerDateReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerDate/CreatePlannerDateReactor.swift
@@ -135,6 +135,10 @@ extension CreatePlannerDateReactor {
     }
 
     func makeCreateTagReactor() -> CreatePlannerTagReactor {
-        .init(provider: ServiceProvider.shared, journey: currentState.journey)
+        .init(
+            provider: ServiceProvider.shared,
+            journey: currentState.journey,
+            viewMode: .create
+        )
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerDate/CreatePlannerDateViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerDate/CreatePlannerDateViewController.swift
@@ -150,7 +150,10 @@ class CreatePlannerDateViewController: NavigationBarViewController, View {
             .distinctUntilChanged()
             .filter { $0 }
             .subscribe(onNext: { [weak self] _ in
-                let createTag = CreatePlannerTagViewController(reactor: reactor.makeCreateTagReactor())
+                let createTag = CreatePlannerTagViewController(
+                    reactor: reactor.makeCreateTagReactor(),
+                    pushPlannerScreen: nil
+                )
 
                 self?.navigationController?.pushViewController(createTag, animated: true)
             })

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagReactor.swift
@@ -13,6 +13,11 @@ import RxDataSources
 final class CreatePlannerTagReactor: Reactor {
     static let MAX_SELECTION_COUNT = 3
 
+    enum ViewMode {
+        case create
+        case join
+    }
+
     enum Action {
         case fetchJourneyTags
         case selectTag(IndexPath)
@@ -32,6 +37,7 @@ final class CreatePlannerTagReactor: Reactor {
     }
 
     struct State {
+        var viewMode: ViewMode
         var journey: Journey
         var sections: [TagSectionModel]
         var nomatterItems: [TagItem] = []
@@ -45,9 +51,10 @@ final class CreatePlannerTagReactor: Reactor {
     let initialState: State
     let provider: ServiceProviderType
 
-    init(provider: ServiceProviderType, journey: Journey) {
+    init(provider: ServiceProviderType, journey: Journey, viewMode: ViewMode) {
         self.provider = provider
         initialState = State(
+            viewMode: viewMode,
             journey: journey,
             sections: CreatePlannerTagReactor.makeSections()
         )

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/CreatePlanner/CreatePlannerTag/CreatePlannerTagViewController.swift
@@ -80,6 +80,8 @@ class CreatePlannerTagViewController: NavigationBarViewController, View {
         setNavigationBarTitleText("여행 취향 태그")
         setNavigationBarTitleTextColor(JYPIOSAsset.textB75.color)
         setNavigationBarTitleFont(JYPIOSFontFamily.Pretendard.medium.font(size: 16))
+        setNavigationBarCloseButtonHidden(reactor?.currentState.viewMode != .join)
+        setNavigationBarBackButtonHidden(reactor?.currentState.viewMode == .join)
     }
 
     override func setupProperty() {
@@ -170,6 +172,20 @@ class CreatePlannerTagViewController: NavigationBarViewController, View {
             .subscribe(onNext: { [weak self] id in
                 self?.navigationController?.popToRootViewController(animated: true)
                 reactor.action.onNext(.successCreatePlanner(id))
+            })
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map(\.viewMode)
+            .asObservable()
+            .distinctUntilChanged()
+            .subscribe(onNext: { mode in
+                switch mode {
+                case .create:
+                    print("Create")
+                case .join:
+                    print("Join")
+                }
             })
             .disposed(by: disposeBag)
     }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/InputPlannerCodeBottomSheetReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/InputPlannerCodeBottomSheetReactor.swift
@@ -25,6 +25,7 @@ final class InputPlannerCodeBottomSheetReactor: Reactor {
         var plannerCode: String?
         var isActivePlannerJoinButton: Bool = false
         var isPushMyPlannerView: String?
+        var guideLabel: String?
     }
 
     var initialState: State = .init()
@@ -50,16 +51,17 @@ final class InputPlannerCodeBottomSheetReactor: Reactor {
         case let .changePlannerCode(code):
             newState.plannerCode = code
         case let .changeActivePlannerJoinButton(isActive):
+            newState.guideLabel = nil
             newState.isActivePlannerJoinButton = isActive
         case let .pushMyPlanner(id):
             newState.isPushMyPlannerView = id
         case let .validateJoin(model):
-            print(model)
             switch model.code {
             case "20000":
-                print("success")
                 newState.isPushMyPlannerView = state.plannerCode
-            default: break
+            default:
+                newState.guideLabel = "잘못된 참여 코드에요"
+                newState.isActivePlannerJoinButton = false
             }
         }
 

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/InputPlannerCodeBottomSheetReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/InputPlannerCodeBottomSheetReactor.swift
@@ -11,20 +11,16 @@ import ReactorKit
 final class InputPlannerCodeBottomSheetReactor: Reactor {
     enum Action {
         case didChangedTextField(String)
-        case didTapJoinCodeButton(String)
     }
 
     enum Mutation {
         case changePlannerCode(String)
         case changeActivePlannerJoinButton(Bool)
-        case pushMyPlanner(String?)
-        case validateJoin(EmptyModel)
     }
 
     struct State {
         var plannerCode: String?
         var isActivePlannerJoinButton: Bool = false
-        var isPushMyPlannerView: String?
         var guideLabel: String?
     }
 
@@ -38,9 +34,6 @@ final class InputPlannerCodeBottomSheetReactor: Reactor {
                 .just(.changeActivePlannerJoinButton(!str.isEmpty)),
                 .just(.changePlannerCode(str))
             ])
-        case let .didTapJoinCodeButton(code):
-            return provider.joinPlanner(journeyId: code)
-                .map { .validateJoin($0) }
         }
     }
 
@@ -53,16 +46,6 @@ final class InputPlannerCodeBottomSheetReactor: Reactor {
         case let .changeActivePlannerJoinButton(isActive):
             newState.guideLabel = nil
             newState.isActivePlannerJoinButton = isActive
-        case let .pushMyPlanner(id):
-            newState.isPushMyPlannerView = id
-        case let .validateJoin(model):
-            switch model.code {
-            case "20000":
-                newState.isPushMyPlannerView = state.plannerCode
-            default:
-                newState.guideLabel = "잘못된 참여 코드에요"
-                newState.isActivePlannerJoinButton = false
-            }
         }
 
         return newState

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/InputPlannerCodeBottomSheetViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/InputPlannerCodeBottomSheetViewController.swift
@@ -73,6 +73,7 @@ class InputPlannerCodeBottomSheetViewController: BottomSheetViewController, View
 
         guideLabel.font = JYPIOSFontFamily.Pretendard.regular.font(size: 12)
         guideLabel.textColor = JYPIOSAsset.mainPink.color
+        guideLabel.textAlignment = .right
 
         textField.textField.leftView = UIView()
         textField.setupToolBar()
@@ -120,6 +121,7 @@ class InputPlannerCodeBottomSheetViewController: BottomSheetViewController, View
 
         guideLabel.snp.makeConstraints { make in
             make.centerY.equalTo(plannerCodeLabel.snp.centerY)
+            make.leading.equalTo(plannerCodeLabel.snp.trailing).offset(5)
             make.trailing.equalTo(cancelButton.snp.trailing)
         }
 
@@ -195,6 +197,13 @@ class InputPlannerCodeBottomSheetViewController: BottomSheetViewController, View
                     )
                 })
             })
+            .disposed(by: disposeBag)
+        
+        reactor.state
+            .map(\.guideLabel)
+            .asObservable()
+            .distinctUntilChanged()
+            .bind(to: guideLabel.rx.text)
             .disposed(by: disposeBag)
     }
 

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/InputPlannerCodeBottomSheetViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/InputPlannerCodeBottomSheetViewController.swift
@@ -13,7 +13,7 @@ class InputPlannerCodeBottomSheetViewController: BottomSheetViewController, View
     typealias Reactor = InputPlannerCodeBottomSheetReactor
 
     private let pushPlannerScreen: (_ id: String) -> PlannerViewController
-    private let pushCreatePlannerTagScreen: () -> CreatePlannerTagViewController
+    private let pushJoinPlannerTagScreen: () -> CreatePlannerTagViewController
 
     // MARK: - Properties
 
@@ -43,7 +43,7 @@ class InputPlannerCodeBottomSheetViewController: BottomSheetViewController, View
         pushCreatePlannerTagScreen: @escaping () -> CreatePlannerTagViewController
     ) {
         self.pushPlannerScreen = pushPlannerScreen
-        self.pushCreatePlannerTagScreen = pushCreatePlannerTagScreen
+        self.pushJoinPlannerTagScreen = pushCreatePlannerTagScreen
         super.init(mode: .drag)
         self.reactor = reactor
     }
@@ -209,7 +209,7 @@ class InputPlannerCodeBottomSheetViewController: BottomSheetViewController, View
 
 extension InputPlannerCodeBottomSheetViewController {
     func willPushCreatePlannerTagViewController() {
-        let viewController = pushCreatePlannerTagScreen()
+        let viewController = pushJoinPlannerTagScreen()
         viewController.modalPresentationStyle = .fullScreen
         
         let keyWindow = UIApplication.shared.connectedScenes

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/SelectionPlannerJoinBottomViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/SelectionPlannerJoinBottomViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 
 class SelectionPlannerJoinBottomViewController: BottomSheetViewController {
     private let pushInputPlannerCodeBottomSheetScreen: () -> InputPlannerCodeBottomSheetViewController
-    
+
     // MARK: - UI Components
 
     private let containerView: UIView = .init()
@@ -24,13 +24,13 @@ class SelectionPlannerJoinBottomViewController: BottomSheetViewController {
     private let joinPlannerView: UIView = .init()
     private let joinPlannerIcon: UIImageView = .init()
     private let joinPlannerLabel: UILabel = .init()
-    
+
     init(mode: BottomSheetViewController.Mode,
          pushInputPlannerCodeBottomSheetScreen: @escaping () -> InputPlannerCodeBottomSheetViewController) {
         self.pushInputPlannerCodeBottomSheetScreen = pushInputPlannerCodeBottomSheetScreen
         super.init(mode: mode)
     }
-    
+
     @available(*, unavailable)
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
@@ -110,52 +110,31 @@ class SelectionPlannerJoinBottomViewController: BottomSheetViewController {
         createPlannerView.rx.tapGesture()
             .when(.recognized)
             .subscribe(onNext: { [weak self] _ in
-                self?.dismiss(animated: true, completion: {
+                guard let self,
+                      let tabBarController = self.presentingViewController as? UITabBarController
+                else { return }
+
+                self.dismiss(animated: true, completion: {
                     let createPlannerViewController = CreatePlannerNameViewController(reactor: .init())
                     createPlannerViewController.hidesBottomBarWhenPushed = true
 
-                    let keyWindow = UIApplication.shared.connectedScenes
-                        .filter { $0.activationState == .foregroundActive }
-                        .map { $0 as? UIWindowScene }
-                        .compactMap { $0 }
-                        .first?.windows
-                        .filter { $0.isKeyWindow }.first
-                    
-                    if let navigationController = keyWindow?.rootViewController?.children.first
-                        as? UINavigationController {
-                        navigationController.pushViewController(
-                            createPlannerViewController,
-                            animated: true)
-                    }
+                    tabBarController.navigationController?.pushViewController(createPlannerViewController, animated: true)
                 })
             })
             .disposed(by: disposeBag)
-        
+
         joinPlannerView.rx.tapGesture()
             .when(.recognized)
             .subscribe(onNext: { [weak self] _ in
-                self?.dismiss(animated: true, completion: {
-                    self?.willPresentInputPlannerCodeBottomSheetViewController()
+                guard let self,
+                      let tabBarController = self.presentingViewController as? UITabBarController
+                else { return }
+
+                self.dismiss(animated: true, completion: {
+                    let viewController = self.pushInputPlannerCodeBottomSheetScreen()
+                    tabBarController.present(viewController, animated: true)
                 })
             })
             .disposed(by: disposeBag)
-    }
-}
-
-extension SelectionPlannerJoinBottomViewController {
-    func willPresentInputPlannerCodeBottomSheetViewController() {
-        let viewController = pushInputPlannerCodeBottomSheetScreen()
-        
-        let keyWindow = UIApplication.shared.connectedScenes
-            .filter { $0.activationState == .foregroundActive }
-            .map { $0 as? UIWindowScene }
-            .compactMap { $0 }
-            .first?.windows
-            .filter { $0.isKeyWindow }.first
-
-        keyWindow?.rootViewController?.present(
-            viewController,
-            animated: true
-        )
     }
 }


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
참여코드로 플래너 입장 구현

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->

- 입장 코드로 플래너에 join할 수 있는 로직을 추가했는데, 잘못된 코드를 입력했을 때 방지하는 로직이 아직 추가되지 않음
  - (PR 쪼개서 진행할게요)
- 탭바 위에서 modal이 present되는 경우가 있어서 rootTabBar에도 navigationController를 씌워줬어요.
  - 13e24385ffa71d1ac7bc53e0df5a89fa8a7294ae
- navigationController에서 CloseButton을 추가했어요.
  - 7bbdbf4393b3c7227d5fbea37e11e6637607955e

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #97 


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->