### PR TITLE
[bug/#114] code 입력 버튼 높이 지정

### DIFF
--- a/JYP-iOS/JYP-iOS/Sources/Presenter/JoinPlanner/InputPlannerCodeBottomSheetViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/JoinPlanner/InputPlannerCodeBottomSheetViewController.swift
@@ -84,6 +84,8 @@ class InputPlannerCodeBottomSheetViewController: BottomSheetViewController, View
         joinCodeButton.backgroundColor = JYPIOSAsset.tagWhiteBlue100.color
         joinCodeButton.setTitleColor(JYPIOSAsset.subBlue300.color, for: .normal)
         joinCodeButton.titleLabel?.lineBreakMode = .byTruncatingTail
+        joinCodeButton.titleLabel?.numberOfLines = 1
+        joinCodeButton.titleEdgeInsets = .init(top: 4, left: 8, bottom: 4, right: 8)
         joinCodeButton.cornerRound(radius: 8)
         joinCodeButton.isHidden = true
 
@@ -137,7 +139,7 @@ class InputPlannerCodeBottomSheetViewController: BottomSheetViewController, View
         joinCodeButton.snp.makeConstraints { make in
             make.top.equalTo(textField.snp.bottom).offset(16)
             make.leading.equalToSuperview()
-            make.width.equalTo(104)
+            make.size.equalTo(CGSize(width: 104, height: 32))
         }
 
         plannerJoinButton.snp.makeConstraints { make in
@@ -205,7 +207,7 @@ class InputPlannerCodeBottomSheetViewController: BottomSheetViewController, View
     }
 
     @objc
-    func changedClipboardString(_ sender: Notification) {
+    private func changedClipboardString(_ sender: Notification) {
         guard let clipboardString: String = sender.object as? String else { return }
 
         setJoinCodeButton(clipboardString)

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/MyPlannerViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/MyPlannerViewController.swift
@@ -38,7 +38,8 @@ class MyPlannerViewController: NavigationBarViewController, View {
 
     init(reactor: Reactor,
          pushSelectionPlannerJoinBottomScreen: @escaping () -> SelectionPlannerJoinBottomViewController,
-         pushPlannerScreen: @escaping (_ id: String) -> PlannerViewController) {
+         pushPlannerScreen: @escaping (_ id: String) -> PlannerViewController
+    ) {
         self.pushSelectionPlannerJoinBottomScreen = pushSelectionPlannerJoinBottomScreen
         self.pushPlannerScreen = pushPlannerScreen
         super.init(nibName: nil, bundle: nil)
@@ -204,7 +205,7 @@ class MyPlannerViewController: NavigationBarViewController, View {
 extension MyPlannerViewController {
     func willPushSelectionPlannerJoinBottomViewController() {
         let viewController = pushSelectionPlannerJoinBottomScreen()
-        
+
         self.tabBarController?.present(viewController, animated: true)
     }
     

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/SelectionPlannerJoinBottomViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/MyPlanner/SelectionPlannerJoinBottomViewController.swift
@@ -25,8 +25,10 @@ class SelectionPlannerJoinBottomViewController: BottomSheetViewController {
     private let joinPlannerIcon: UIImageView = .init()
     private let joinPlannerLabel: UILabel = .init()
 
-    init(mode: BottomSheetViewController.Mode,
-         pushInputPlannerCodeBottomSheetScreen: @escaping () -> InputPlannerCodeBottomSheetViewController) {
+    init(
+        mode: BottomSheetViewController.Mode,
+        pushInputPlannerCodeBottomSheetScreen: @escaping () -> InputPlannerCodeBottomSheetViewController
+    ) {
         self.pushInputPlannerCodeBottomSheetScreen = pushInputPlannerCodeBottomSheetScreen
         super.init(mode: mode)
     }
@@ -111,14 +113,15 @@ class SelectionPlannerJoinBottomViewController: BottomSheetViewController {
             .when(.recognized)
             .subscribe(onNext: { [weak self] _ in
                 guard let self,
-                      let tabBarController = self.presentingViewController as? UITabBarController
+                      let tabBarController = self.presentingViewController as? UITabBarController,
+                      let firstViewController = tabBarController.children.first as? UINavigationController
                 else { return }
 
                 self.dismiss(animated: true, completion: {
                     let createPlannerViewController = CreatePlannerNameViewController(reactor: .init())
                     createPlannerViewController.hidesBottomBarWhenPushed = true
 
-                    tabBarController.navigationController?.pushViewController(createPlannerViewController, animated: true)
+                    firstViewController.pushViewController(createPlannerViewController, animated: true)
                 })
             })
             .disposed(by: disposeBag)


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
플래너 입장하기 뷰에서 복사된 code 버튼이 길어져서 높이 지정해줌

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
<img src="https://user-images.githubusercontent.com/26399850/214308159-19ca7a9b-a6a7-4c86-a6af-d8148539bf5b.PNG" width=300 />
텍스트가 길어지면 하늘색 버튼도 함께 길어져서 높이 지정을 해줬습니다 / padding값도 지정

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #114


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->