### PR TITLE
[Bugfix/#116] textField에 값 변경 시 x 버튼이 나타나지 않는 버그

### DIFF
--- a/JYP-iOS/JYP-iOS/Sources/Extension/Rx+Ext.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Extension/Rx+Ext.swift
@@ -10,7 +10,7 @@ import RxCocoa
 import RxSwift
 import UIKit
 
-public extension Reactive where Base: UIViewController {
+extension Reactive where Base: UIViewController {
     var viewDidLoad: ControlEvent<Void> {
         let source = methodInvoked(#selector(Base.viewDidLoad)).map { _ in }
         return ControlEvent(events: source)
@@ -20,9 +20,26 @@ public extension Reactive where Base: UIViewController {
         let source = methodInvoked(#selector(Base.viewWillAppear)).map { $0.first as? Bool ?? false }
         return ControlEvent(events: source)
     }
-    
+
     var viewDidAppear: ControlEvent<Bool> {
         let source = methodInvoked(#selector(Base.viewDidAppear)).map { $0.first as? Bool ?? false }
         return ControlEvent(events: source)
+    }
+}
+
+extension Reactive where Base: UITextField {
+    /// textField의 focus 이벤트를 제외하고 text 값이 변경될 때 방출된다
+    var changedText: ControlProperty<String?> {
+        base.rx.controlProperty(
+            editingEvents: [.editingChanged, .valueChanged],
+            getter: { textField in
+                textField.text
+            },
+            setter: { textField, value in
+                if textField.text != value {
+                    textField.text = value
+                }
+            }
+        )
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Resuable/JYPSearchTextField.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Resuable/JYPSearchTextField.swift
@@ -54,10 +54,10 @@ struct JYPSeachTextFieldConfig {
 }
 
 final class JYPSearchTextField: BaseView {
-    let type: JYPSearchTextFieldType
-    let textField = UITextField()
-    let trailingButton = UIButton()
-    let bottomBorderLine = UIView()
+    private let type: JYPSearchTextFieldType
+    private(set) var textField = UITextField()
+    private let trailingButton = UIButton()
+    private let bottomBorderLine = UIView()
 
     private lazy var textfieldValueChangedEvent = Observable.merge(
         textField.rx.changedText.asObservable(),

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Resuable/JYPSearchTextField.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Resuable/JYPSearchTextField.swift
@@ -6,6 +6,8 @@
 //  Copyright © 2022 JYP-iOS. All rights reserved.
 //
 
+import RxCocoa
+import RxSwift
 import UIKit
 
 enum JYPSearchTextFieldType {
@@ -13,7 +15,7 @@ enum JYPSearchTextFieldType {
     case region
     case tag
     case planner
-    
+
     var config: JYPSeachTextFieldConfig {
         switch self {
         case .place:
@@ -26,7 +28,7 @@ enum JYPSearchTextFieldType {
             return .init(placeholderText: "예) 제주도 여행기", font: JYPIOSFontFamily.Pretendard.semiBold.font(size: 24), textColor: JYPIOSAsset.textB90.color, backgroundColor: JYPIOSAsset.backgroundWhite100.color)
         }
     }
-    
+
     var trailingIcon: UIImage {
         switch self {
         case .place, .region:
@@ -35,7 +37,7 @@ enum JYPSearchTextFieldType {
             return UIImage()
         }
     }
-    
+
     var isHiddenBottomBorder: Bool {
         switch self {
         case .place, .region: return true
@@ -51,82 +53,86 @@ struct JYPSeachTextFieldConfig {
     let backgroundColor: UIColor
 }
 
-class JYPSearchTextField: BaseView {
+final class JYPSearchTextField: BaseView {
     let type: JYPSearchTextFieldType
     let textField = UITextField()
     let trailingButton = UIButton()
     let bottomBorderLine = UIView()
-    
+
+    private lazy var textfieldValueChangedEvent = Observable.merge(
+        textField.rx.changedText.asObservable(),
+        textField.rx.observe(String.self, "text")
+    ).asObservable().compactMap { $0 }
+
+    @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("not supported")
     }
-    
+
     init(type: JYPSearchTextFieldType) {
         self.type = type
-        
+
         super.init(frame: .zero)
     }
-    
+
     override func setupProperty() {
         super.setupProperty()
-        
+
         backgroundColor = type.config.backgroundColor
-        
+
         textField.leftView = UIView(frame: CGRect(x: 0, y: 0, width: 16, height: textField.frame.height))
         textField.leftViewMode = .always
         textField.tintColor = JYPIOSAsset.textB90.color
         textField.placeholder = type.config.placeholderText
         textField.font = type.config.font
         textField.textColor = type.config.textColor
-        
+
         trailingButton.setImage(type.trailingIcon, for: .normal)
         trailingButton.setImage(JYPIOSAsset.iconTextDelete.image, for: .selected)
-        
+
         bottomBorderLine.backgroundColor = .black.withAlphaComponent(0.1)
         bottomBorderLine.isHidden = type.isHiddenBottomBorder
     }
-    
+
     override func setupHierarchy() {
         super.setupHierarchy()
-        
+
         addSubviews([textField, trailingButton, bottomBorderLine])
     }
-    
+
     override func setupLayout() {
         super.setupLayout()
-        
+
         textField.snp.makeConstraints {
             $0.top.leading.bottom.equalToSuperview()
             $0.trailing.equalTo(trailingButton.snp.leading).offset(-6)
         }
-        
+
         trailingButton.snp.makeConstraints {
             $0.trailing.equalToSuperview().inset(12)
             $0.centerY.equalToSuperview()
             $0.width.height.equalTo(20)
         }
-        
+
         bottomBorderLine.snp.makeConstraints { make in
             make.bottom.equalTo(textField.snp.bottom)
             make.leading.trailing.equalToSuperview()
             make.height.equalTo(1)
         }
     }
-    
+
     override func setupBind() {
         super.setupBind()
-        
-        textField.rx.text.orEmpty
+
+        textfieldValueChangedEvent
+            .distinctUntilChanged()
+            .map { !$0.isEmpty }
             .withUnretained(self)
-            .bind { this, text in
-                if text.isEmpty {
-                    this.trailingButton.isSelected = false
-                } else {
-                    this.trailingButton.isSelected = true
-                }
+            .bind { this, isNotEmpty in
+                this.trailingButton.isSelected = isNotEmpty
             }
             .disposed(by: disposeBag)
-        
+
         trailingButton.rx.tap
             .withUnretained(self)
             .bind { this, _ in
@@ -137,7 +143,7 @@ class JYPSearchTextField: BaseView {
             }
             .disposed(by: disposeBag)
     }
-    
+
     func setupToolBar() {
         let toolbar = UIToolbar()
         let flexSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
@@ -148,9 +154,9 @@ class JYPSearchTextField: BaseView {
         toolbar.updateConstraintsIfNeeded()
         textField.inputAccessoryView = toolbar
     }
-    
+
     @objc
-    func didTapDoneButton(_ sender: UIBarButtonItem) {
-        self.textField.resignFirstResponder()
+    private func didTapDoneButton(_ sender: UIBarButtonItem) {
+        textField.resignFirstResponder()
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Resuable/JYPSearchTextField.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Resuable/JYPSearchTextField.swift
@@ -135,7 +135,7 @@ final class JYPSearchTextField: BaseView {
 
         trailingButton.rx.tap
             .withUnretained(self)
-            .bind { this, _ in
+            .subscribe { this, _ in
                 if this.trailingButton.isSelected {
                     this.textField.text = ""
                     this.trailingButton.isSelected = false


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
textField에 값 변경 시 x 버튼이 나타나지 않는 버그 해결

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
rx.`text`를 사용할 경우, `textField.text = ""`와 같은 직접적인 값 대입의 이벤트를 받지 못합니다. (controlEvent만 받음)
따라서 rx.`observe` (KVO 방식)으로 text property의 변경 이벤트를 구독해 textField 값 변경을 구독했습니다. 

- `JYPSearchTextField` 내의 property 접근연산자 / 클래스 final 수정

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->
`JYPSearchTextField`내의 `trailingButton`이 보여지는지 여부를 `isSelected`로 조절하는 것이 직관적이지는 않아보입니다.
`isSelected` 변수로는 '선택되었는지'만 판단하는 것이 어떨까요?


#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #116


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->