### PR TITLE
Bugfix/#133 카카오 로그인 콜백이 불리지 않음

### DIFF
--- a/JYP-iOS/JYP-iOS/Sources/AppDelegate.swift
+++ b/JYP-iOS/JYP-iOS/Sources/AppDelegate.swift
@@ -7,7 +7,6 @@
 
 import UIKit
 import KakaoSDKCommon
-import KakaoSDKAuth
 #if targetEnvironment(simulator)
 #else
     import GoogleMaps
@@ -24,12 +23,5 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             GMSServices.provideAPIKey(Environment.googleAPIKey)
         #endif
         return true
-    }
-    
-    func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        if AuthApi.isKakaoTalkLoginUrl(url) {
-            return AuthController.handleOpenUrl(url: url)
-        }
-        return false
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/OnboardingSignUp/OnboardingSignUpViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/OnboardingSignUp/OnboardingSignUpViewController.swift
@@ -15,110 +15,112 @@ import KakaoSDKUser
 
 class OnboardingSignUpViewController: NavigationBarViewController, View {
     // MARK: - Properties
-    
+
     typealias Reactor = OnboardingSignUpReactor
-    
+
     private let pushOnboardingQuestionJourneyScreen: () -> OnboardingQuestionJourneyViewController
-    
+
     // MARK: - UI Components
-    
+
     let onboardingView = UIView()
     let onboardingLogoImageView = UIImageView()
     let onboardinglogoTextImageView = UIImageView()
     let loginLabel = UILabel()
     let kakaoLoginButton = UIButton()
     let appleLoginButton = ASAuthorizationAppleIDButton()
-    
+
     // MARK: - Initializer
-    
-    init(reactor: OnboardingSignUpReactor,
-         pushOnboardingQuestionJourneyScreen: @escaping () -> OnboardingQuestionJourneyViewController) {
+
+    init(
+        reactor: OnboardingSignUpReactor,
+        pushOnboardingQuestionJourneyScreen: @escaping () -> OnboardingQuestionJourneyViewController
+    ) {
         self.pushOnboardingQuestionJourneyScreen = pushOnboardingQuestionJourneyScreen
         super.init(nibName: nil, bundle: nil)
-        
+
         self.reactor = reactor
     }
-    
+
     @available(*, unavailable)
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - Setup Methods
-    
+
     override func setupNavigationBar() {
         super.setupNavigationBar()
-        
+
         setNavigationBarBackgroundColor(JYPIOSAsset.mainPink.color)
         setNavigationBarBackButtonHidden(true)
         setNavigationBarHidden(true)
     }
-    
+
     override func setupProperty() {
         super.setupProperty()
-        
+
         view.backgroundColor = JYPIOSAsset.backgroundWhite100.color
-        
+
         onboardingView.backgroundColor = JYPIOSAsset.mainPink.color
         onboardingView.cornerRound(radius: 40, direct: [.layerMaxXMaxYCorner, .layerMinXMaxYCorner])
-        
+
         onboardingLogoImageView.image = JYPIOSAsset.onboardingLogo.image
-        
+
         onboardinglogoTextImageView.image = JYPIOSAsset.onboardingTextLogoWhite.image
-        
+
         loginLabel.text = "SNS 계정으로 회원가입 및 로그인"
         loginLabel.font = JYPIOSFontFamily.Pretendard.regular.font(size: 14)
         loginLabel.textColor = JYPIOSAsset.textB40.color
-        
+
         kakaoLoginButton.setBackgroundImage(JYPIOSAsset.kakaoLogin.image, for: .normal)
-        
+
         appleLoginButton.cornerRound(radius: 6)
     }
-    
+
     override func setupHierarchy() {
         super.setupHierarchy()
-        
+
         contentView.addSubviews([onboardingView, loginLabel, kakaoLoginButton, appleLoginButton])
         onboardingView.addSubviews([onboardingLogoImageView, onboardinglogoTextImageView])
     }
-    
+
     override func setupLayout() {
         super.setupLayout()
-        
+
         onboardingView.snp.makeConstraints {
             $0.top.leading.trailing.equalTo(view.safeAreaLayoutGuide)
         }
-        
+
         onboardingLogoImageView.snp.makeConstraints {
             $0.top.equalToSuperview().inset(152)
             $0.centerX.equalToSuperview()
             $0.width.height.equalTo(87)
         }
-        
+
         onboardinglogoTextImageView.snp.makeConstraints {
             $0.top.equalTo(onboardingLogoImageView.snp.bottom).offset(8)
             $0.centerX.equalToSuperview()
         }
-        
+
         loginLabel.snp.makeConstraints {
             $0.top.equalTo(onboardingView.snp.bottom).offset(71)
             $0.centerX.equalToSuperview()
             $0.bottom.equalTo(kakaoLoginButton.snp.top).offset(-19)
         }
-        
+
         kakaoLoginButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(24)
             $0.bottom.equalTo(appleLoginButton.snp.top).offset(-13)
             $0.height.equalTo(50)
         }
-        
+
         appleLoginButton.snp.makeConstraints {
             $0.leading.trailing.equalToSuperview().inset(24)
             $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(40)
             $0.height.equalTo(50)
         }
     }
-    
+
     func bind(reactor: OnboardingSignUpReactor) {
         kakaoLoginButton.rx.tap
             .bind { [weak self] _ in
@@ -127,7 +129,7 @@ class OnboardingSignUpViewController: NavigationBarViewController, View {
                 }
             }
             .disposed(by: disposeBag)
-        
+
         appleLoginButton.rx.tapGesture()
             .when(.recognized)
             .filter { $0.state == .ended }
@@ -135,7 +137,7 @@ class OnboardingSignUpViewController: NavigationBarViewController, View {
                 self?.willPresentAppleLoginScreen()
             }
             .disposed(by: disposeBag)
-        
+
         reactor.state
             .map(\.didLogin)
             .filter { $0 }
@@ -150,75 +152,62 @@ class OnboardingSignUpViewController: NavigationBarViewController, View {
 
 extension OnboardingSignUpViewController: ASAuthorizationControllerDelegate, ASAuthorizationControllerPresentationContextProviding {
     private func willPresentKakaoLoginScreen(completion: @escaping (String, String?, String?) -> Void) {
-        //TODO: 카카오톡 로그인 해결 후 주석 제거
-//        if UserApi.isKakaoTalkLoginAvailable() {
-//            UserApi.shared.loginWithKakaoTalk {(oauthToken, error) in
-//                if let error = error {
-//                    print(error)
-//                } else if let token = oauthToken?.accessToken {
-//                    UserApi.shared.me { (user, _) in
-//                        if let error = error {
-//                            print(error)
-//                        } else {
-//                            let name = user?.properties?["nickname"]
-//                            let profileImagePath = user?.properties?["profile_image"]
-//
-//                            completion(token, name, profileImagePath)
-//                        }
-//                    }
-//                }
-//            }
-//        } else {
-            UserApi.shared.loginWithKakaoAccount {(oauthToken, error) in
-                if let error = error {
-                    print(error)
-                } else if let token = oauthToken?.accessToken {
-                    UserApi.shared.me { (user, _) in
-                        if let error = error {
-                            print(error)
-                        } else {
-                            let name = user?.properties?["nickname"]
-                            let profileImagePath = user?.properties?["profile_image"]
-                            
-                            completion(token, name, profileImagePath)
-                        }
-                    }
+        if UserApi.isKakaoTalkLoginAvailable() {
+            UserApi.shared.loginWithKakaoTalk { oauthToken, error in
+                guard error == nil, let token = oauthToken?.accessToken else { return }
+
+                UserApi.shared.me { user, _ in
+                    let name = user?.properties?["nickname"]
+                    let profileImagePath = user?.properties?["profile_image"]
+
+                    completion(token, name, profileImagePath)
                 }
             }
-//        }
+        } else {
+            UserApi.shared.loginWithKakaoAccount { oauthToken, error in
+                guard error == nil, let token = oauthToken?.accessToken else { return }
+
+                UserApi.shared.me { user, _ in
+                    let name = user?.properties?["nickname"]
+                    let profileImagePath = user?.properties?["profile_image"]
+
+                    completion(token, name, profileImagePath)
+                }
+            }
+        }
     }
-    
+
     private func willPresentAppleLoginScreen() {
         let appleIDProvider = ASAuthorizationAppleIDProvider()
         let request = appleIDProvider.createRequest()
         request.requestedScopes = [.fullName, .email]
-        
+
         let authorizationController = ASAuthorizationController(authorizationRequests: [request])
         authorizationController.delegate = self
         authorizationController.presentationContextProvider = self
         authorizationController.performRequests()
     }
-    
+
     func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return self.view.window!
     }
-    
+
     func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         switch authorization.credential {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
             let fullName = appleIDCredential.fullName
             let name = (fullName?.givenName ?? "") + (fullName?.familyName ?? "")
-            
+
             if let identityToken = appleIDCredential.identityToken,
                let token = String(data: identityToken, encoding: .utf8) {
                 reactor?.action.onNext(.login(authVendor: .apple, token: token, name: name, profileImagePath: nil))
             }
-            
+
         default:
             break
         }
     }
-    
+
     func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         print(error)
     }
@@ -227,6 +216,6 @@ extension OnboardingSignUpViewController: ASAuthorizationControllerDelegate, ASA
 extension OnboardingSignUpViewController {
     func willPushOnboardingQuestionJourneyViewController() {
         let viewController = pushOnboardingQuestionJourneyScreen()
-        self.navigationController?.pushViewController(viewController, animated: true)
+        navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Project.swift
+++ b/Project.swift
@@ -41,7 +41,12 @@ class BaseProjectFactory: ProjectFactory {
         "SERVER_HOST": "$(SERVER_HOST)",
         "SERVER_JWT_MASTER_KEY": "$(SERVER_JWT_MASTER_KEY)",
         "GOOGLE_API_KEY": "$(GOOGLE_API_KEY)",
-        "CFBundleURLTypes": ["CFBundleURLSchemes": ["kakao$(KAKAO_APP_KEY)"]],
+        "CFBundleURLTypes": [
+            [
+                "CFBundleTypeRole": "Editor",
+                "CFBundleURLSchemes": ["kakao$(KAKAO_APP_KEY)"]
+            ]
+        ],
         "UIApplicationSceneManifest": [
             "UIApplicationSupportsMultipleScenes": false,
             "UISceneConfigurations": [


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->
카카오 앱으로 로그인 할 때 콜백이 불리지 않았던 이슈를 해결함

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->
- `Project.swift` 파일의 `infoPlist` 설정에서 대괄호가 빠져있었어요
- 그래서 target > info > `URL Types`로 잡히지 않고, `untitled`로 잡히고 있어서 발생한 문제
(SceneDelegate의 `openURL` 함수가 호출되지 않았음)
- 불필요해보이는 코드를 좀 정리했어요. 필수적이라고 생각되는 코드라면 코멘트 부탁드립니다.

- `invalid android_key_hash or ios_bundle_id or web_site_ur`l 에러는 #131 에서 fix 될까요?

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->
이거 하나 찾는데 진짜 오래걸렸네요 .. 

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #133 


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->