### PR TITLE
[Feat/#142] 프로필 이미지 선택 바텀 시트 구현

### DIFF
--- a/JYP-iOS/JYP-iOS/Sources/CompositionRoot.swift
+++ b/JYP-iOS/JYP-iOS/Sources/CompositionRoot.swift
@@ -31,7 +31,15 @@ final class CompositionRoot {
         }
         
         lazy var pushTabBarScreen: () -> TabBarViewController = {
-            return makeTabBarScreen(pushOnboardingScreen: pushOnboardingScreen)
+            let pushCreateProfileBottomSheetScreen: () -> CreateProfileBottomSheetViewController = {
+                let reactor = CreateProfileBottomSheetReactor(onboardingService: onboardingService,
+                                                              userService: userService)
+                let viewController = CreateProfileBottomSheetViewController(reactor: reactor)
+                
+                return viewController
+            }
+            
+            return makeTabBarScreen(pushOnboardingScreen: pushOnboardingScreen, pushCreateProfileBottomSheetScreen: pushCreateProfileBottomSheetScreen)
         }
         
         if KeychainAccess.get(key: .accessToken) != nil && UserDefaultsAccess.get(key: .userID) != nil {
@@ -50,8 +58,10 @@ final class CompositionRoot {
 }
 
 extension CompositionRoot {
-    static func makeTabBarScreen(pushOnboardingScreen: @escaping () -> OnboardingOneViewController) -> TabBarViewController {
-        let viewController = TabBarViewController()
+    static func makeTabBarScreen(pushOnboardingScreen: @escaping () -> OnboardingOneViewController,
+                                 pushCreateProfileBottomSheetScreen: @escaping () -> CreateProfileBottomSheetViewController) -> TabBarViewController {
+        let reactor = TabBarReactor()
+        let viewController = TabBarViewController(reactor: reactor, pushCreateProfileBottomSheetScreen: pushCreateProfileBottomSheetScreen)
 
         let myPlannerViewController = makeMyPlannerScreen()
         let anotherJourneyViewController = makeAnotherJourneyScreen()

--- a/JYP-iOS/JYP-iOS/Sources/Config/KeychainAccess.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Config/KeychainAccess.swift
@@ -12,8 +12,6 @@ import KeychainAccess
 
 enum KeychainAccessKey: String {
     case accessToken
-    case nickname
-    case profileImagePath
 }
 
 final class KeychainAccess {

--- a/JYP-iOS/JYP-iOS/Sources/Config/UserDefaultsAccess.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Config/UserDefaultsAccess.swift
@@ -10,6 +10,9 @@ import Foundation
 
 enum UserDefaultsAccessKey: String {
     case userID
+    case nickname
+    case profileImagePath
+    case personality
 }
 
 final class UserDefaultsAccess {

--- a/JYP-iOS/JYP-iOS/Sources/Extension/UIStackView+Ext.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Extension/UIStackView+Ext.swift
@@ -1,0 +1,23 @@
+//
+//  UIStackView+Ext.swift
+//  JYP-iOS
+//
+//  Created by 송영모 on 2023/01/29.
+//  Copyright © 2023 JYP-iOS. All rights reserved.
+//
+
+import UIKit
+
+extension UIStackView {
+    func addArrangedSubviews(_ views: [UIView]) {
+        for view in views {
+            addArrangedSubview(view)
+        }
+    }
+
+    func removeArrangedSubviews() {
+        for view in arrangedSubviews {
+            view.removeFromSuperview()
+        }
+    }
+}

--- a/JYP-iOS/JYP-iOS/Sources/Model/PersonalityID.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Model/PersonalityID.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2022 JYP-iOS. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 enum PersonalityID: String, Codable {
     case ME
@@ -28,6 +28,34 @@ enum PersonalityID: String, Codable {
             return "낭만적인 여행자"
         case .FW:
             return "자유로운 방랑자"
+        }
+    }
+    
+    var image: UIImage? {
+        switch self {
+        case .ME:
+            return JYPIOSAsset.profile1.image
+        case .PE:
+            return JYPIOSAsset.profile2.image
+        case .RT:
+            return JYPIOSAsset.profile3.image
+        case .FW:
+            return JYPIOSAsset.profile4.image
+        }
+    }
+    
+    static func toSelf(title: String) -> PersonalityID {
+        switch title {
+        case PersonalityID.ME.title:
+            return .ME
+        case PersonalityID.PE.title:
+            return .PE
+        case PersonalityID.RT.title:
+            return .RT
+        case PersonalityID.FW.title:
+            return .FW
+        default:
+            return .ME
         }
     }
 

--- a/JYP-iOS/JYP-iOS/Sources/Model/PersonalityID.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Model/PersonalityID.swift
@@ -31,16 +31,16 @@ enum PersonalityID: String, Codable {
         }
     }
     
-    var image: UIImage? {
+    var defaultImagePath: String {
         switch self {
         case .ME:
-            return JYPIOSAsset.profile1.image
+            return "https://journeypiki.duckdns.org/static/profile_me.png"
         case .PE:
-            return JYPIOSAsset.profile2.image
+            return "https://journeypiki.duckdns.org/static/profile_pe.png"
         case .RT:
-            return JYPIOSAsset.profile3.image
+            return "https://journeypiki.duckdns.org/static/profile_rt.png"
         case .FW:
-            return JYPIOSAsset.profile4.image
+            return "https://journeypiki.duckdns.org/static/profile_fw.png"
         }
     }
     

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/BottomSheet/BottomSheetViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/BottomSheet/BottomSheetViewController.swift
@@ -28,11 +28,11 @@ class BottomSheetViewController: BaseViewController {
     private let mode: Mode
     
     private lazy var MAX_ALPHA: CGFloat = {
-        self.mode == .drag ? 0.75 : 0.0
+        self.mode == .drag ? 0.75 : 0.75
     }()
     
     private lazy var dimmedColor: UIColor = {
-        self.mode == .drag ? JYPIOSAsset.backgroundDim70.color : .clear
+        self.mode == .drag ? JYPIOSAsset.backgroundDim70.color : JYPIOSAsset.backgroundDim70.color
     }()
     
     // MARK: - Initializer

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/MyPage/MyPageReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/MyPage/MyPageReactor.swift
@@ -28,6 +28,7 @@ extension MyPageReactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case .logout:
+            UserDefaultsAccess.remove(key: .userID)
             KeychainAccess.remove(key: .accessToken)
             return .empty()
         }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/CreateProfileBottomSheet/CreateProfileBottomSheetReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/CreateProfileBottomSheet/CreateProfileBottomSheetReactor.swift
@@ -1,0 +1,68 @@
+//
+//  CreateProfileBottomSheetReactor.swift
+//  JYP-iOS
+//
+//  Created by 송영모 on 2023/01/29.
+//  Copyright © 2023 JYP-iOS. All rights reserved.
+//
+
+import ReactorKit
+
+class CreateProfileBottomSheetReactor: Reactor {
+    enum Action {
+        case refresh
+        case tapButton
+    }
+    
+    enum Mutation {
+        case setNickname(String)
+        case setPersonalityID(PersonalityID)
+    }
+    
+    struct State {
+        var nickname: String?
+        var personalityID: PersonalityID?
+        var isActive: Bool = false
+    }
+    
+    var initialState: State
+    
+    let onboardingService: OnboardingServiceType
+    let userService: UserServiceType
+    
+    init(onboardingService: OnboardingServiceType,
+         userService: UserServiceType) {
+        self.onboardingService = onboardingService
+        self.userService = userService
+        self.initialState = .init()
+    }
+}
+
+extension CreateProfileBottomSheetReactor {
+    func mutate(action: Action) -> Observable<Mutation> {
+        switch action {
+        case .refresh:
+            return .concat([
+                .just(.setNickname(UserDefaultsAccess.get(key: .nickname) ?? "")),
+                .just(.setPersonalityID(PersonalityID.toSelf(title: UserDefaultsAccess.get(key: .personality) ?? "")))
+            ])
+            
+        case .tapButton:
+            return .empty()
+        }
+    }
+    
+    func reduce(state: State, mutation: Mutation) -> State {
+        var newState = state
+        
+        switch mutation {
+        case let .setNickname(nickname):
+            newState.nickname = nickname
+            
+        case let .setPersonalityID(id):
+            newState.personalityID = id
+        }
+        
+        return newState
+    }
+}

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/CreateProfileBottomSheet/CreateProfileBottomSheetViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/CreateProfileBottomSheet/CreateProfileBottomSheetViewController.swift
@@ -1,0 +1,96 @@
+//
+//  CreateProfileBottomSheetViewController.swift
+//  JYP-iOS
+//
+//  Created by 송영모 on 2023/01/29.
+//  Copyright © 2023 JYP-iOS. All rights reserved.
+//
+
+import Foundation
+
+import UIKit
+import ReactorKit
+import RxSwift
+
+class CreateProfileBottomSheetViewController: BottomSheetViewController, View {
+    typealias Reactor = CreateProfileBottomSheetReactor
+    
+    // MARK: - UI Components
+    
+    let containerView: UIView = .init()
+    let titleLabel: UILabel = .init()
+    let button: UIButton = .init()
+    let scrollView: UIScrollView = .init()
+    let stackView: UIStackView = .init()
+    
+    // MARK: - Initializer
+    
+    init(reactor: Reactor) {
+        super.init(mode: .drag)
+        
+        self.reactor = reactor
+    }
+    
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        addContentView(view: containerView)
+    }
+    
+    // MARK: - Setup Methods
+    
+    override func setupProperty() {
+        super.setupProperty()
+  
+        titleLabel.font = JYPIOSFontFamily.Pretendard.semiBold.font(size: 20)
+        titleLabel.textColor = JYPIOSAsset.textB80.color
+        
+        button.setTitle("확인", for: .normal)
+        button.setTitleColor(JYPIOSAsset.textB40.color, for: .normal)
+        button.titleLabel?.font = JYPIOSFontFamily.Pretendard.regular.font(size: 16)
+        
+        stackView.distribution = .equalSpacing
+        stackView.spacing = 12
+        stackView.alignment = .leading
+    }
+    
+    override func setupHierarchy() {
+        super.setupHierarchy()
+        
+        containerView.addSubviews([titleLabel, button, stackView])
+    }
+    
+    override func setupLayout() {
+        super.setupLayout()
+        
+        titleLabel.snp.makeConstraints {
+            $0.top.equalToSuperview().inset(4)
+            $0.leading.equalToSuperview()
+        }
+        
+        button.snp.makeConstraints {
+            $0.trailing.equalToSuperview()
+            $0.centerY.equalTo(titleLabel)
+        }
+        
+        stackView.snp.makeConstraints {
+            $0.top.leading.trailing.bottom.equalToSuperview()
+            $0.height.equalToSuperview()
+        }
+    }
+    
+    func bind(reactor: Reactor) {
+        Observable.zip(
+            reactor.state.compactMap(\.nickname).asObservable(),
+            reactor.state.compactMap(\.personalityID).asObservable()
+        )
+        .map { String(describing: "\($0)님은\n\($1.title)이시군요!") }
+        .bind(to: titleLabel.rx.text)
+        .disposed(by: disposeBag)
+    }
+}

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/OnboardingQuestion/OnboardingQuestionJourneyViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/OnboardingQuestion/OnboardingQuestionJourneyViewController.swift
@@ -73,14 +73,9 @@ class OnboardingQuestionJourneyViewController: NavigationBarViewController, View
             .disposed(by: disposeBag)
         
         onboardingQuestionView.nextButton.rx.tap
-            .withUnretained(self)
-            .bind { this, action in
-                if let isActive = this.reactor?.currentState.isActive {
-                    if isActive {
-                        this.reactor?.action.onNext(.tapNextButton)
-                        this.willPushOnboardingQuestionPlaceViewController()
-                    }
-                }
+            .filter { reactor.currentState.isActive }
+            .bind { [weak self] _ in
+                self?.willPushOnboardingQuestionPlaceViewController()
             }
             .disposed(by: disposeBag)
         

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/OnboardingQuestion/OnboardingQuestionPlaceViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/OnboardingQuestion/OnboardingQuestionPlaceViewController.swift
@@ -68,14 +68,9 @@ class OnboardingQuestionPlaceViewController: NavigationBarViewController, View {
             .disposed(by: disposeBag)
         
         onboardingQuestionView.nextButton.rx.tap
-            .withUnretained(self)
-            .bind { this, action in
-                if let isActive = this.reactor?.currentState.isActive {
-                    if isActive {
-                        this.reactor?.action.onNext(.tapNextButton)
-                        this.willPushOnboardingQuestionPlanViewController()
-                    }
-                }
+            .filter { reactor.currentState.isActive }
+            .bind { [weak self] _ in
+                self?.willPushOnboardingQuestionPlanViewController()
             }
             .disposed(by: disposeBag)
         

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/OnboardingQuestion/OnboardingQuestionPlanViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/OnboardingQuestion/OnboardingQuestionPlanViewController.swift
@@ -66,11 +66,6 @@ class OnboardingQuestionPlanViewController: NavigationBarViewController, View {
             .disposed(by: disposeBag)
         
         onboardingQuestionView.nextButton.rx.tap
-            .map { .tapNextButton }
-            .bind(to: reactor.action)
-            .disposed(by: disposeBag)
-        
-        onboardingQuestionView.nextButton.rx.tap
             .filter { reactor.currentState.isActive }
             .bind { [weak self] _ in
                 self?.willPresentTabBarViewController()

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/OnboardingQuestion/OnboardingQuestionReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/OnboardingQuestion/OnboardingQuestionReactor.swift
@@ -18,7 +18,6 @@ class OnboardingQuestionReactor: Reactor {
     enum Action {
         case tapFirstView
         case tapSecondView
-        case tapNextButton
     }
     
     enum Mutation {
@@ -71,18 +70,18 @@ class OnboardingQuestionReactor: Reactor {
                 .just(.setIsActive(true))
             ])
             
-        case .tapNextButton:
-            switch mode {
-            case .joruney, .place:
-                return .empty()
-                
-            case .plan:
-                let name = KeychainAccess.get(key: .nickname) ?? ""
-                let profileImagePath = KeychainAccess.get(key: .profileImagePath) ?? ""
-                
-                userService.createUser(request: .init(name: name, profileImagePath: profileImagePath, personalityId: onboardingService.getPersonalityID()))
-                return .empty()
-            }
+//        case .tapNextButton:
+//            switch mode {
+//            case .joruney, .place:
+//                return .empty()
+//                
+//            case .plan:
+//                let name = KeychainAccess.get(key: .nickname) ?? ""
+//                let profileImagePath = KeychainAccess.get(key: .profileImagePath) ?? ""
+//                
+//                userService.createUser(request: .init(name: name, profileImagePath: profileImagePath, personalityId: onboardingService.getPersonalityID()))
+//                return .empty()
+//            }
         }
     }
     

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/OnboardingSignUp/OnboardingSignUpReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Onboarding/OnboardingSignUp/OnboardingSignUpReactor.swift
@@ -74,16 +74,12 @@ extension OnboardingSignUpReactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case let .login(authVendor, token, name, profileImagePath):
-            if let name = name {
-                if name.isEmpty == false {
-                    KeychainAccess.set(key: .nickname, value: name)
-                }
+            if let name = name, !name.isEmpty {
+                UserDefaultsAccess.set(key: .nickname, value: name)
             }
             
-            if let profileImagePath = profileImagePath {
-                if profileImagePath.isEmpty == false {
-                    KeychainAccess.set(key: .profileImagePath, value: profileImagePath)
-                }
+            if let profileImagePath = profileImagePath, !profileImagePath.isEmpty {
+                UserDefaultsAccess.set(key: .profileImagePath, value: profileImagePath)
             }
             
             switch authVendor {

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/TagBottomSheet/Components/ProfileBoxView.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/TagBottomSheet/Components/ProfileBoxView.swift
@@ -10,16 +10,35 @@ import UIKit
 import Kingfisher
 
 class ProfileBox: BaseView {
+    // MARK: - Properties
+    
+    var isSelected: Bool = false {
+        didSet {
+            if isSelected {
+                checkImageView.isHidden = false
+            } else {
+                checkImageView.isHidden = true
+            }
+        }
+    }
+    
     // MARK: - UI Components
     
     let imageView: UIImageView = .init()
+    let checkImageView: UIImageView = .init(image: JYPIOSAsset.iconCheck.image)
     let titleLabel: UILabel = .init()
     
     // MARK: - Initializer
     
-    init(imagePath: String, title: String) {
+    init(imagePath: String? = nil, title: String? = nil) {
         super.init(frame: .zero)
         
+        if let imagePath = imagePath {
+            update(imagePath: imagePath, title: title)
+        }
+    }
+    
+    func update(imagePath: String, title: String?) {
         imageView.kf.setImage(with: URL(string: imagePath))
         
         titleLabel.text = title
@@ -37,13 +56,16 @@ class ProfileBox: BaseView {
         super.setupProperty()
         
         imageView.cornerRound(radius: 12)
+        
         titleLabel.textAlignment = .center
+        
+        checkImageView.isHidden = true
     }
     
     override func setupHierarchy() {
         super.setupHierarchy()
         
-        addSubviews([imageView, titleLabel])
+        addSubviews([imageView, titleLabel, checkImageView])
     }
     
     override func setupLayout() {
@@ -60,6 +82,12 @@ class ProfileBox: BaseView {
             $0.leading.trailing.equalToSuperview()
             $0.width.equalTo(60)
             $0.bottom.equalToSuperview()
+        }
+        
+        checkImageView.snp.makeConstraints {
+            $0.top.equalTo(imageView.snp.top).offset(-11)
+            $0.trailing.equalTo(imageView.snp.trailing).offset(-8)
+            $0.width.height.equalTo(40)
         }
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/TagBottomSheet/Components/ProfileBoxView.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/TagBottomSheet/Components/ProfileBoxView.swift
@@ -10,6 +10,13 @@ import UIKit
 import Kingfisher
 
 class ProfileBox: BaseView {
+    // MARK: - Sub Type
+    
+    enum ProfileBoxType {
+        case create
+        case tag
+    }
+    
     // MARK: - Properties
     
     var isSelected: Bool = false {
@@ -22,6 +29,8 @@ class ProfileBox: BaseView {
         }
     }
     
+    let type: ProfileBoxType
+    
     // MARK: - UI Components
     
     let imageView: UIImageView = .init()
@@ -30,7 +39,8 @@ class ProfileBox: BaseView {
     
     // MARK: - Initializer
     
-    init(imagePath: String? = nil, title: String? = nil) {
+    init(type: ProfileBoxType, imagePath: String? = nil, title: String? = nil) {
+        self.type = type
         super.init(frame: .zero)
         
         if let imagePath = imagePath {
@@ -71,10 +81,18 @@ class ProfileBox: BaseView {
     override func setupLayout() {
         super.setupLayout()
         
-        imageView.snp.makeConstraints {
-            $0.top.equalToSuperview()
-            $0.centerX.equalToSuperview()
-            $0.width.height.equalTo(44)
+        if type == .create {
+            imageView.snp.makeConstraints {
+                $0.top.equalToSuperview()
+                $0.centerX.equalToSuperview()
+                $0.width.height.equalTo(70)
+            }
+        } else {
+            imageView.snp.makeConstraints {
+                $0.top.equalToSuperview()
+                $0.centerX.equalToSuperview()
+                $0.width.height.equalTo(44)
+            }
         }
         
         titleLabel.snp.makeConstraints {

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/TagBottomSheet/TagBottomSheetViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Planner/Planner/TagBottomSheet/TagBottomSheetViewController.swift
@@ -104,7 +104,7 @@ class TagBottomSheetViewController: BottomSheetViewController, View {
         tag.titleLabel.text = reactor.currentState.tag.topic
         
         reactor.currentState.tag.users.forEach {
-            stackView.addArrangedSubview(ProfileBox(imagePath: $0.profileImagePath, title: $0.nickname))
+            stackView.addArrangedSubview(ProfileBox(type: .tag, imagePath: $0.profileImagePath, title: $0.nickname))
         }
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/TabBar/TabBarReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/TabBar/TabBarReactor.swift
@@ -1,0 +1,26 @@
+//
+//  TabBarReactor.swift
+//  JYP-iOS
+//
+//  Created by 송영모 on 2023/01/29.
+//  Copyright © 2023 JYP-iOS. All rights reserved.
+//
+
+import ReactorKit
+
+class TabBarReactor: Reactor {
+    enum Action {
+    }
+    
+    enum Mutation {
+    }
+    
+    struct State {
+    }
+    
+    var initialState: State
+    
+    init() {
+        self.initialState = .init()
+    }
+}

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/TabBar/TabBarViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/TabBar/TabBarViewController.swift
@@ -8,33 +8,55 @@
 
 import Foundation
 import UIKit
+import ReactorKit
 
-class TabBarViewController: UITabBarController {
+class TabBarViewController: UITabBarController, View {
+    // MARK: - Properties
+    
+    typealias Reactor = TabBarReactor
+    
+    private let pushCreateProfileBottomSheetScreen: () -> CreateProfileBottomSheetViewController
+    
+    var disposeBag = DisposeBag()
+    
+    // MARK: - Initializer
+    
+    init(reactor: Reactor,
+         pushCreateProfileBottomSheetScreen: @escaping () -> CreateProfileBottomSheetViewController) {
+        self.pushCreateProfileBottomSheetScreen = pushCreateProfileBottomSheetScreen
+        super.init(nibName: nil, bundle: nil)
+        self.reactor = reactor
+    }
+    
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - View Lifecylce
+    
     override func viewDidLoad() {
         super.viewDidLoad()
+        
         tabBar.backgroundColor = .white
         tabBar.isTranslucent = false
         tabBar.layer.borderWidth = 1.0
         tabBar.layer.borderColor = .init(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.1)
-//
-//        let myPlannerReactor = MyPlannerReactor()
-//        let myPlannerNavigationViewController = MyPlannerViewController(reactor: myPlannerReactor)
-//        let myPlannerTabBarItem = UITabBarItem(title: nil, image: JYPIOSAsset.myJourneyInactive.image.withRenderingMode(.alwaysOriginal), selectedImage: JYPIOSAsset.myJourneyActive.image.withRenderingMode(.alwaysOriginal))
-//        myPlannerTabBarItem.imageInsets = .init(top: 9, left: 0, bottom: -9, right: 0)
-//
-//        let anotherJourneyViewController = UINavigationController(rootViewController: AnotherJourneyViewController())
-//        let anotherJourneyTabBarItem = UITabBarItem(title: nil, image: JYPIOSAsset.anotherJourneyInactive.image.withRenderingMode(.alwaysOriginal), selectedImage: JYPIOSAsset.anotherJourneyActive.image.withRenderingMode(.alwaysOriginal))
-//        anotherJourneyTabBarItem.imageInsets = .init(top: 9, left: 0, bottom: -9, right: 0)
-//
-//        let myPageNavigationViewController = UINavigationController(rootViewController: MyPageViewController())
-//        let myPageTabBarItem = UITabBarItem(title: nil, image: JYPIOSAsset.myPageInactive.image.withRenderingMode(.alwaysOriginal), selectedImage: JYPIOSAsset.myPageActive.image.withRenderingMode(.alwaysOriginal))
-//        myPageTabBarItem.imageInsets = .init(top: 9, left: 0, bottom: -9, right: 0)
-//
-//        myPlannerNavigationViewController.tabBarItem = myPlannerTabBarItem
-//        anotherJourneyViewController.tabBarItem = anotherJourneyTabBarItem
-//        myPageNavigationViewController.tabBarItem = myPageTabBarItem
-//
-//        viewControllers = [myPlannerNavigationViewController, anotherJourneyViewController, myPageNavigationViewController]
-//        selectedIndex = 0
+    }
+
+    func bind(reactor: Reactor) {
+        rx.viewDidLoad
+            .filter { _ in UserDefaultsAccess.get(key: .userID) != nil }
+            .subscribe(onNext: { [weak self] _ in
+                self?.willPresentCreateProfileBottomSheetViewController()
+            })
+            .disposed(by: disposeBag)
+    }
+}
+extension TabBarViewController {
+    func willPresentCreateProfileBottomSheetViewController() {
+        let viewController = pushCreateProfileBottomSheetScreen()
+        
+        tabBarController?.present(viewController, animated: true)
     }
 }

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/TabBar/TabBarViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/TabBar/TabBarViewController.swift
@@ -45,8 +45,8 @@ class TabBarViewController: UITabBarController, View {
     }
 
     func bind(reactor: Reactor) {
-        rx.viewDidLoad
-            .filter { _ in UserDefaultsAccess.get(key: .userID) != nil }
+        rx.viewWillAppear
+            .filter { _ in UserDefaultsAccess.get(key: .userID) == nil }
             .subscribe(onNext: { [weak self] _ in
                 self?.willPresentCreateProfileBottomSheetViewController()
             })
@@ -57,6 +57,6 @@ extension TabBarViewController {
     func willPresentCreateProfileBottomSheetViewController() {
         let viewController = pushCreateProfileBottomSheetScreen()
         
-        tabBarController?.present(viewController, animated: true)
+        present(viewController, animated: true)
     }
 }


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->

이제부터는 프로필 이미지를 선택해야 유저를 생성할 수 있습니다. 

간단히 API 플로우를 요약하면

로그인 API (kakao or apple) -> [GET] users/me user id가 있는지 확인
if users/me. user id가 있다면
-> 탭바 행
else
-> 탭바 행 & 프로필 바텀 시트 -> [POST] users user 생성 -> 생성 후 탭바 닫힘

<img src="https://user-images.githubusercontent.com/77970826/215320383-7cf0ce3e-cf36-4512-be66-8b99397bfd24.png" width="30%">

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #142


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->