### PR TITLE
[Bugfix/#199] iPhone mini에서 캘린더 바텀시트가 뜨지 않는 버그

### DIFF
--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Calendar/CalendarViewController.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Calendar/CalendarViewController.swift
@@ -43,7 +43,7 @@ class CalendarViewController: BottomSheetViewController, View {
 
         addContentView(view: datePicker)
         datePicker.snp.makeConstraints { make in
-            make.height.equalTo(380)
+            make.height.equalTo(420)
         }
     }
 

--- a/JYP-iOS/JYP-iOS/Sources/Presenter/Calendar/CalenderReactor.swift
+++ b/JYP-iOS/JYP-iOS/Sources/Presenter/Calendar/CalenderReactor.swift
@@ -56,6 +56,9 @@ extension CalendarReactor {
     func mutate(action: Action) -> Observable<Mutation> {
         switch action {
         case let .selectDateAction(date):
+            let dateString = DateManager.dateToString(format: "yyyy-MM-dd", date: date)
+            let date = DateManager.stringToDate(format: "yyyy-MM-dd", date: dateString)
+            
             switch mode {
             case .start:
                 return service.updateStartDate(to: date).map { _ in .dismiss }


### PR DESCRIPTION
## PR 요약
<!-- 해당 pr에서 작업한 내역을 적어주세요. -->

해당 버그가 재현이 안되어서, 우선 캘린더 높이를 40 증가시키는 판단을 하였습니다.

#### 📌 변경 사항
<!-- 변경사항 및 주의 사항 (모듈 설치 등)을 적어주세요. -->

##### ✅ PR check list
<!-- 피드백 받고 싶거나, 공유할 사항을 적어주세요 -->

#### Linked Issue
<!-- 해결한 이슈 넘버를 붙여주세요. -->
close #199


<!-- PR 요청 전 마지막 확인!
- commit message가 적절한지 확인해주세요. 
- 마지막으로 Coding Convention을 준수했는지 확인해주세요.
- 적절한 branch로 요청했는지 확인해주세요.
- Assignees, Label을 붙여주세요.
- 해결한 이슈를 Link 해주세요.
- PR이 승인된 경우 해당 브랜치는 삭제해주세요.
-->